### PR TITLE
Preliminary work on using DimArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [extensions]
-FlexiChainsDynamicPPLExt = ["DynamicPPL", "Random"]
+FlexiChainsDynamicPPLExt = ["DynamicPPL", "Random", "DimensionalData"]
 FlexiChainsMCMCChainsExt = ["MCMCChains", "OrderedCollections"]
 FlexiChainsTuringExt = ["Turing"]
 

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.0.2"
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -24,6 +25,7 @@ FlexiChainsTuringExt = ["Turing"]
 [compat]
 AbstractMCMC = "5"
 AbstractPPL = "0.13.1"
+DimensionalData = "0.29.24"
 DocStringExtensions = "0.9"
 DynamicPPL = "0.37, 0.38"
 OrderedCollections = "1"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ chain = sample(f(), NUTS(), 1000; chain_type=VNChain)
 ```
 
 You can index into a `VNChain` using `VarName`s.
+Data is returned as a `DimMatrix` from the [`DimensionalData.jl` package](https://rafaqz.github.io/DimensionalData.jl/), which behaves exactly like an ordinary `Matrix` but additionally carries more information about its dimensions.
 
 ```julia
-chain[@varname(x)]    # -> Vector{Float64}
-chain[@varname(y)]    # -> Vector{Vector{Float64}}
-chain[@varname(y[1])] # -> Vector{Float64}
+chain[@varname(x)]    # -> DimMatrix{Float64}
+chain[@varname(y)]    # -> DimMatrix{Vector{Float64}}
+chain[@varname(y[1])] # -> DimMatrix{Float64}
 ```
 
 Applying summary functions to the chain returns a summary object, which can be indexed into in the same way:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 FlexiChains = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,11 @@
 using Documenter
+using DocumenterInterLinks
 using FlexiChains
 using Statistics: Statistics
+
+links = InterLinks(
+    "DimensionalData" => "https://rafaqz.github.io/DimensionalData.jl/stable/"
+)
 
 makedocs(;
     sitename="FlexiChains.jl",
@@ -8,4 +13,5 @@ makedocs(;
     pages=["index.md", "turing.md", "details.md", "whynew.md"],
     checkdocs=:exports,
     doctest=false,
+    plugins=[links],
 )

--- a/docs/src/details.md
+++ b/docs/src/details.md
@@ -13,10 +13,18 @@ FlexiChains.FlexiChain
 ```
 
 Each chain also stores information about which iterations and chains it contains.
+The iteration indices are typically provided by the MCMC sampler (e.g. in Turing.jl); the chain indices on the other hand will usually just `1:nchains`.
 
 ```@docs
 FlexiChains.iter_indices
 FlexiChains.chain_indices
+```
+
+To renumber these indices you can use:
+
+```@docs
+FlexiChains.renumber_iters
+FlexiChains.renumber_chains
 ```
 
 ## Metadata

--- a/docs/src/details.md
+++ b/docs/src/details.md
@@ -12,6 +12,13 @@ Indeed, a `FlexiChain` contains a `_data` field which is just a dictionary that 
 FlexiChains.FlexiChain
 ```
 
+Each chain also stores information about which iterations and chains it contains.
+
+```@docs
+FlexiChains.iter_indices
+FlexiChains.chain_indices
+```
+
 ## Metadata
 
 Before we discuss the actual _data_ stored in a `FlexiChain`, we note that it also contains a `_metadata` field.

--- a/docs/src/turing.md
+++ b/docs/src/turing.md
@@ -51,11 +51,13 @@ For example, this directly gives us the value of `mu` in each iteration as a pla
 chain[@varname(mu)]
 ```
 
-!!! note "Multiple chains"
+!!! note "DimMatrix"
     
-    If you sample multiple chains, e.g. with `sample(model, NUTS(), MCMCThreads(), 1000, 3; chain_type=VNChain)`, then indexing into the `FlexiChain` will give you a matrix of floats instead.
+    Indexing into a `FlexiChain` returns a [`DimensionalData.DimMatrix`](@extref DimensionalData DimArrays). This behaves exactly like a regular `Matrix`, but additionally carries extra information about its dimensions.
+    
+    This allows you to keep track of what each dimension means, and also allows for more advanced indexing operations. Please see [the DimensionalData.jl documentation](https://rafaqz.github.io/DimensionalData.jl/) for more details.
 
-For vector-valued parameters like `theta`, this works in exactly the same way, except that you get a vector of vectors (note: not a matrix).
+For vector-valued parameters like `theta`, this works in exactly the same way, except that you get a `DimMatrix` of vectors (note: _not_ a 3D array).
 
 ```@example 1
 chain[@varname(theta)]
@@ -162,7 +164,7 @@ chn = vcat(chn1, chn2)
     For **multiple-chain sampling** with `sample(model, spl, MCMCThreads(), N, C)`, `initial_state` should be a vector of length `C`, where `initial_state[i]` is the state to resume the `i`-th chain from (or `nothing` to start a new chain).
     
     To obtain the saved final state of a chain, you can use [`FlexiChains.last_sampler_state`](@ref).
-    This is either a single state or a vector of states (depending on how many chains were sampled).
+    This returns a vector of states with length equal to the number of chains.
     
     The above applies equally to `MCMCSerial()` and `MCMCDistributed()`.
 

--- a/ext/FlexiChainsDynamicPPLExt.jl
+++ b/ext/FlexiChainsDynamicPPLExt.jl
@@ -51,8 +51,13 @@ end
 #     DELETE WHEN POSSIBLE    #
 ###############################
 
-function DynamicPPL.loadstate(chain::FlexiChain)
+function DynamicPPL.loadstate(
+    chain::FlexiChain{TKey,NIter,NChain}
+) where {TKey<:VarName,NIter,NChain}
     st = FlexiChains.last_sampler_state(chain)
+    if NChain == 1
+        st = only(st)
+    end
     st === nothing && error(
         "attempted to resume sampling from a chain without a saved state; you must pass `save_state=true` when sampling the previous chain",
     )

--- a/ext/FlexiChainsMCMCChainsExt.jl
+++ b/ext/FlexiChainsMCMCChainsExt.jl
@@ -66,7 +66,11 @@ function MCMCChains.Chains(vnchain::FlexiChain{<:VarName,NIter,NChain}) where {N
     info = (varname_to_symbol=OrderedDict(zip(varnames, varname_symbols)),)
     # See comment above for the use of 'internals' as the only section.
     return MCMCChains.Chains(
-        all_values, all_symbols, (; internals=internal_keys); info=info
+        all_values,
+        all_symbols,
+        (; internals=internal_keys);
+        info=info,
+        iterations=FlexiChains.iter_indices(vnchain),
     )
 end
 

--- a/ext/FlexiChainsTuringExt.jl
+++ b/ext/FlexiChainsTuringExt.jl
@@ -9,8 +9,8 @@ using Turing: Turing, AbstractMCMC
 
 function FlexiChains.to_varname_dict(
     transition::Turing.Inference.Transition
-)::Dict{ParameterOrExtra{VarName},Any}
-    d = Dict{ParameterOrExtra{VarName},Any}()
+)::Dict{ParameterOrExtra{<:VarName},Any}
+    d = Dict{ParameterOrExtra{<:VarName},Any}()
     for (varname, value) in pairs(transition.θ)
         d[Parameter(varname)] = value
     end

--- a/ext/FlexiChainsTuringExt.jl
+++ b/ext/FlexiChainsTuringExt.jl
@@ -33,8 +33,8 @@ function AbstractMCMC.bundle_samples(
     chain_type::Type{T};
     save_state=false,
     stats=missing,
-    # discard_initial::Int=0,
-    # thinning::Int=1,
+    discard_initial::Int=0,
+    thinning::Int=1,
     _kwargs...,
 )::T where {TKey<:VarName,T<:FlexiChain{TKey}}
     NIter = length(transitions)
@@ -43,10 +43,17 @@ function AbstractMCMC.bundle_samples(
     tm = stats === missing ? nothing : stats.stop - stats.start
     # last sampler state
     st = save_state ? last_sampler_state : nothing
+    # calculate iteration indices
+    start = discard_initial + 1
+    iter_indices = if thinning != 1
+        range(start; step=thinning, length=NIter)
+    else
+        # This returns UnitRange not StepRange -- a bit cleaner
+        start:(start + NIter - 1)
+    end
     return FlexiChain{TKey,NIter,1}(
         dicts;
-        # TODO: Fix iter_indices
-        iter_indices=1:NIter,
+        iter_indices=iter_indices,
         # 1:1 gives nicer DimMatrix output than just [1]
         chain_indices=1:1,
         sampling_time=tm,

--- a/ext/FlexiChainsTuringExt.jl
+++ b/ext/FlexiChainsTuringExt.jl
@@ -36,13 +36,22 @@ function AbstractMCMC.bundle_samples(
     # discard_initial::Int=0,
     # thinning::Int=1,
     _kwargs...,
-)::T where {T<:FlexiChain{<:VarName}}
+)::T where {TKey<:VarName,T<:FlexiChain{TKey}}
+    NIter = length(transitions)
     dicts = map(FlexiChains.to_varname_dict, transitions)
     # timings
     tm = stats === missing ? nothing : stats.stop - stats.start
     # last sampler state
     st = save_state ? last_sampler_state : nothing
-    return T(dicts; sampling_time=tm, last_sampler_state=st)
+    return FlexiChain{TKey,NIter,1}(
+        dicts;
+        # TODO: Fix iter_indices
+        iter_indices=1:NIter,
+        # 1:1 gives nicer DimMatrix output than just [1]
+        chain_indices=1:1,
+        sampling_time=tm,
+        last_sampler_state=st,
+    )
 end
 
 end # module FlexiChainsTuringExt

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -1,6 +1,7 @@
 using AbstractMCMC: AbstractChains
 
 @public FlexiChain, Parameter, Extra, ParameterOrExtra
+@public iter_indices, chain_indices, renumber_iter, renumber_chain
 @public sampling_time, last_sampler_state
 
 """
@@ -333,6 +334,47 @@ numbers from the sampler: for example, if you discard the first 100 iterations a
 The accuracy of this field is reliant on the sampler providing this information, though.
 """
 iter_indices(chain::FlexiChain{T,NI,NC,TIIdx}) where {T,NI,NC,TIIdx} = chain._iter_indices
+
+"""
+    renumber_iter(
+        chain::FlexiChain,
+        iter_indices::AbstractVector{<:Integer}=1:NIter
+    )
+
+Return a copy of `chain` with the iteration indices replaced by `iter_indices`.
+"""
+function renumber_iter(
+    chain::FlexiChain{TKey,NIter,NChain}, iter_indices::AbstractVector{<:Integer}=1:NIter
+)::FlexiChain{TKey,NIter,NChain} where {TKey,NIter,NChain}
+    return FlexiChain{TKey,NIter,NChain}(
+        chain._data;
+        iter_indices=iter_indices,
+        chain_indices=chain_indices(chain),
+        sampling_time=sampling_time(chain),
+        last_sampler_state=last_sampler_state(chain),
+    )
+end
+
+"""
+    renumber_chain(
+        chain::FlexiChain,
+        chain_indices::AbstractVector{<:Integer}=1:NChains
+    )
+
+Return a copy of `chain` with the chain indices replaced by `chain_indices`.
+"""
+function renumber_chain(
+    chain::FlexiChain{TKey,NIter,NChains},
+    chain_indices::AbstractVector{<:Integer}=1:NChains,
+)::FlexiChain{TKey,NIter,NChains} where {TKey,NIter,NChains}
+    return FlexiChain{TKey,NIter,NChains}(
+        chain._data;
+        iter_indices=iter_indices(chain),
+        chain_indices=chain_indices,
+        sampling_time=sampling_time(chain),
+        last_sampler_state=last_sampler_state(chain),
+    )
+end
 
 """
     chain_indices(chain::FlexiChain)

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -88,7 +88,10 @@ end
 
 """
     struct FlexiChain{
-        TKey,NIter,NChains,TMetadata<:NTuple{NChains,FlexiChainMetadata}
+        TKey,NIter,NChains,
+        TIIdx<:AbstractVector{<:Integer},
+        TCIdx<:AbstractVector{<:Integer},
+        TMetadata<:NTuple{NChains,FlexiChainMetadata}
     } <: AbstractMCMC.AbstractChains
 
 An MCMC chain.
@@ -105,8 +108,14 @@ TODO: Document further.
 
 $(TYPEDFIELDS)
 """
-struct FlexiChain{TKey,NIter,NChains,TMetadata<:NTuple{NChains,FlexiChainMetadata}} <:
-       AbstractChains
+struct FlexiChain{
+    TKey,
+    NIter,
+    NChains,
+    TIIdx<:AbstractVector{<:Integer},
+    TCIdx<:AbstractVector{<:Integer},
+    TMetadata<:NTuple{NChains,FlexiChainMetadata},
+} <: AbstractChains
     """
     Internal per-iteration data for parameters and extra keys. To access the data
     in here, you should index into the chain.
@@ -120,13 +129,13 @@ struct FlexiChain{TKey,NIter,NChains,TMetadata<:NTuple{NChains,FlexiChainMetadat
 
     Do not access this directly; you can use [`iter_indices`](@ref) instead.
     """
-    _iter_indices::AbstractVector{Int}
+    _iter_indices::TIIdx
 
     """
     The indices of each MCMC chain in the chain. This will pretty much always be `1:NChains`
     (unless the chain has been subsetted).
     """
-    _chain_indices::AbstractVector{Int}
+    _chain_indices::TCIdx
 
     """
     Other items associated with the chain. These are not necessarily per-iteration (for
@@ -214,7 +223,9 @@ struct FlexiChain{TKey,NIter,NChains,TMetadata<:NTuple{NChains,FlexiChainMetadat
             ]...,
         )
 
-        return new{TKey,NIter,NChains,typeof(metadata)}(
+        return new{
+            TKey,NIter,NChains,typeof(iter_indices),typeof(chain_indices),typeof(metadata)
+        }(
             data, iter_indices, chain_indices, metadata
         )
     end
@@ -296,7 +307,9 @@ struct FlexiChain{TKey,NIter,NChains,TMetadata<:NTuple{NChains,FlexiChainMetadat
             ]...,
         )
 
-        return new{TKey,NIter,NChains,typeof(metadata)}(
+        return new{
+            TKey,NIter,NChains,typeof(iter_indices),typeof(chain_indices),typeof(metadata)
+        }(
             data, iter_indices, chain_indices, metadata
         )
     end
@@ -311,7 +324,7 @@ numbers from the sampler: for example, if you discard the first 100 iterations a
 
 The accuracy of this field is reliant on the sampler providing this information, though.
 """
-iter_indices(chain::FlexiChain) = chain._iter_indices
+iter_indices(chain::FlexiChain{T,NI,NC,TIIdx}) where {T,NI,NC,TIIdx} = chain._iter_indices
 
 """
     chain_indices(chain::FlexiChain)
@@ -319,7 +332,8 @@ iter_indices(chain::FlexiChain) = chain._iter_indices
 The indices of each MCMC chain in the chain. This will pretty much always be `1:NChains`
 (unless the chain has been subsetted).
 """
-chain_indices(chain::FlexiChain) = chain._chain_indices
+chain_indices(chain::FlexiChain{T,NI,NC,TIIdx,TCIdx}) where {T,NI,NC,TIIdx,TCIdx} =
+    chain._chain_indices
 
 """
     sampling_time(chain::FlexiChain)

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -1,7 +1,7 @@
 using AbstractMCMC: AbstractChains
 
 @public FlexiChain, Parameter, Extra, ParameterOrExtra
-@public iter_indices, chain_indices, renumber_iter, renumber_chain
+@public iter_indices, chain_indices, renumber_iters, renumber_chains
 @public sampling_time, last_sampler_state
 
 """
@@ -336,14 +336,14 @@ The accuracy of this field is reliant on the sampler providing this information,
 iter_indices(chain::FlexiChain{T,NI,NC,TIIdx}) where {T,NI,NC,TIIdx} = chain._iter_indices
 
 """
-    renumber_iter(
+    renumber_iters(
         chain::FlexiChain,
         iter_indices::AbstractVector{<:Integer}=1:NIter
     )
 
 Return a copy of `chain` with the iteration indices replaced by `iter_indices`.
 """
-function renumber_iter(
+function renumber_iters(
     chain::FlexiChain{TKey,NIter,NChain}, iter_indices::AbstractVector{<:Integer}=1:NIter
 )::FlexiChain{TKey,NIter,NChain} where {TKey,NIter,NChain}
     return FlexiChain{TKey,NIter,NChain}(
@@ -356,14 +356,14 @@ function renumber_iter(
 end
 
 """
-    renumber_chain(
+    renumber_chains(
         chain::FlexiChain,
         chain_indices::AbstractVector{<:Integer}=1:NChains
     )
 
 Return a copy of `chain` with the chain indices replaced by `chain_indices`.
 """
-function renumber_chain(
+function renumber_chains(
     chain::FlexiChain{TKey,NIter,NChains},
     chain_indices::AbstractVector{<:Integer}=1:NChains,
 )::FlexiChain{TKey,NIter,NChains} where {TKey,NIter,NChains}

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -51,7 +51,7 @@ end
 _check_length(n::Int, ::Missing, ::AbstractString) = fill(missing, n)
 function _check_length(n::Int, v::AbstractVector, s::AbstractString)
     if length(v) != n
-        msg = "expected `$s` to have length $n (the number of chains), got $(length(v))."
+        msg = "expected `$s` to have length $n, got $(length(v))."
         throw(DimensionMismatch(msg))
     end
     return v
@@ -60,7 +60,7 @@ function _check_length(n::Int, v::Any, s::AbstractString)
     if n == 1
         return [v]
     else
-        msg = "expected `$s` to be a vector of length $n (the number of chains), but got $(typeof(v))."
+        msg = "expected `$s` to be a vector of length $n, but got $(typeof(v))."
         throw(DimensionMismatch(msg))
     end
 end
@@ -188,6 +188,10 @@ struct FlexiChain{
         sampling_time::Any=missing,
         last_sampler_state::Any=missing,
     ) where {TKey,NIter,NChains}
+        # Check iter and chain indices
+        iter_indices = _check_length(NIter, iter_indices, "iter_indices")
+        chain_indices = _check_length(NChains, chain_indices, "chain_indices")
+
         # Extract all unique keys from the dictionaries
         keys_set = Set{ParameterOrExtra{<:TKey}}()
         for d in array_of_dicts
@@ -271,6 +275,10 @@ struct FlexiChain{
         sampling_time::Any=missing,
         last_sampler_state::Any=missing,
     ) where {TKey,NIter,NChains}
+        # Check iter and chain indices
+        iter_indices = _check_length(NIter, iter_indices, "iter_indices")
+        chain_indices = _check_length(NChains, chain_indices, "chain_indices")
+
         data = Dict{ParameterOrExtra{<:TKey},SizedMatrix{NIter,NChains}}()
         for (key, array) in pairs(dict_of_arrays)
             # Check key type

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -3,15 +3,15 @@ const ChainOrSummary{TKey,NIter,NChain} = Union{
 }
 
 """
-    Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
-    Base.getindex(summary::FlexiChainSummary{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
+    Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{<:TKey}) where {TKey}
+    Base.getindex(summary::FlexiChainSummary{TKey}, key::ParameterOrExtra{<:TKey}) where {TKey}
 
 Unambiguously access the data corresponding to the given `key` in the `chain`.
 
 You will need to use this method if you have multiple keys that convert to the
 same `Symbol`, such as a `Parameter(:x)` and an `Extra(:some_section, :x)`.
 """
-function Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
+function Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{<:TKey}) where {TKey}
     return data(
         chain._data[key];
         iter_indices=iter_indices(chain),
@@ -19,17 +19,17 @@ function Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{TKey}) whe
     )
 end
 function Base.getindex(
-    chain::FlexiChainSummaryI{TKey}, key::ParameterOrExtra{TKey}
+    chain::FlexiChainSummaryI{TKey}, key::ParameterOrExtra{<:TKey}
 ) where {TKey}
     return data_anon_iter(chain._data[key]; chain_indices=chain_indices(chain))
 end
 function Base.getindex(
-    chain::FlexiChainSummaryC{TKey}, key::ParameterOrExtra{TKey}
+    chain::FlexiChainSummaryC{TKey}, key::ParameterOrExtra{<:TKey}
 ) where {TKey}
     return data_anon_chain(chain._data[key]; iter_indices=iter_indices(chain))
 end
 function Base.getindex(
-    chain::FlexiChainSummaryIC{TKey}, key::ParameterOrExtra{TKey}
+    chain::FlexiChainSummaryIC{TKey}, key::ParameterOrExtra{<:TKey}
 ) where {TKey}
     return only(data(chain._data[key]))
 end
@@ -55,7 +55,7 @@ actual key.
 """
 function Base.getindex(chain::ChainOrSummary{TKey}, sym_key::Symbol) where {TKey}
     # Convert all keys to symbols and see if there is a unique match
-    potential_keys = ParameterOrExtra{TKey}[]
+    potential_keys = ParameterOrExtra{<:TKey}[]
     for k in keys(chain._data)
         sym = if k isa Parameter{<:TKey}
             # TODO: What happens if Symbol(...) fails on some weird type?

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -14,7 +14,9 @@ function Base.getindex(
     chain::ChainOrSummary{TKey}, key::ParameterOrExtra{TKey}
 ) where {TKey}
     return data(
-        chain[key]; iter_indices=iter_indices(chain), chain_indices=chain_indices(chain)
+        chain._data[key];
+        iter_indices=iter_indices(chain),
+        chain_indices=chain_indices(chain),
     )
 end
 """

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -3,24 +3,39 @@ const ChainOrSummary{TKey,NIter,NChain} = Union{
 }
 
 """
-    Base.getindex(chain::ChainOrSummary{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
+    Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
+    Base.getindex(summary::FlexiChainSummary{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
 
 Unambiguously access the data corresponding to the given `key` in the `chain`.
 
 You will need to use this method if you have multiple keys that convert to the
 same `Symbol`, such as a `Parameter(:x)` and an `Extra(:some_section, :x)`.
 """
-function Base.getindex(
-    chain::ChainOrSummary{TKey}, key::ParameterOrExtra{TKey}
-) where {TKey}
+function Base.getindex(chain::FlexiChain{TKey}, key::ParameterOrExtra{TKey}) where {TKey}
     return data(
         chain._data[key];
         iter_indices=iter_indices(chain),
         chain_indices=chain_indices(chain),
     )
 end
+function Base.getindex(
+    chain::FlexiChainSummaryI{TKey}, key::ParameterOrExtra{TKey}
+) where {TKey}
+    return data_anon_iter(chain._data[key]; chain_indices=chain_indices(chain))
+end
+function Base.getindex(
+    chain::FlexiChainSummaryC{TKey}, key::ParameterOrExtra{TKey}
+) where {TKey}
+    return data_anon_chain(chain._data[key]; iter_indices=iter_indices(chain))
+end
+function Base.getindex(
+    chain::FlexiChainSummaryIC{TKey}, key::ParameterOrExtra{TKey}
+) where {TKey}
+    return only(data(chain._data[key]))
+end
 """
-    Base.getindex(chain::ChainOrSummary{TKey}, sym_key::Symbol) where {TKey}
+    Base.getindex(chain::FlexiChain{TKey}, sym_key::Symbol) where {TKey}
+    Base.getindex(summary::FlexiChainSummary{TKey}, sym_key::Symbol) where {TKey}
 
 The most convenient method to index into a `ChainOrSummary` is using `Symbol`.
 
@@ -71,7 +86,8 @@ function Base.getindex(chain::ChainOrSummary{TKey}, sym_key::Symbol) where {TKey
     end
 end
 """
-    Base.getindex(chain::ChainOrSummary{TKey}, section_name::Symbol, key_name::Any) where {TKey}
+    Base.getindex(chain::FlexiChain{TKey}, section_name::Symbol, key_name::Any) where {TKey}
+    Base.getindex(summary::FlexiChainSummary{TKey}, section_name::Symbol, key_name::Any) where {TKey}
 
 Convenience method for retrieving non-parameter keys. Equal to
 `chain[Extra(section_name, key_name)]`.

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -13,7 +13,9 @@ same `Symbol`, such as a `Parameter(:x)` and an `Extra(:some_section, :x)`.
 function Base.getindex(
     chain::ChainOrSummary{TKey}, key::ParameterOrExtra{TKey}
 ) where {TKey}
-    return _get(chain, key)
+    return data(
+        chain[key]; iter_indices=iter_indices(chain), chain_indices=chain_indices(chain)
+    )
 end
 """
     Base.getindex(chain::ChainOrSummary{TKey}, sym_key::Symbol) where {TKey}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -163,7 +163,7 @@ end
     )::FlexiChain{TKey,NIter,NChain} where {TKey,NIter,NChain}
 
 Create a new `FlexiChain` containing only the specified keys and the data corresponding to
-them.
+them. All metadata is preserved.
 """
 function subset(
     chain::FlexiChain{TKey,NIter,NChain}, keys::AbstractVector{<:ParameterOrExtra{<:TKey}}
@@ -177,7 +177,11 @@ function subset(
         end
     end
     return FlexiChain{TKey,NIter,NChain}(
-        d; iter_indices=iter_indices(chain), chain_indices=chain_indices(chain)
+        d;
+        iter_indices=iter_indices(chain),
+        chain_indices=chain_indices(chain),
+        sampling_time=sampling_time(chain),
+        last_sampler_state=last_sampler_state(chain),
     )
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -342,16 +342,8 @@ function Base.vcat(
 )::FlexiChain{TKey,NIter1 + NIter2,NChains} where {TKey,NIter1,NIter2,NChains}
     d = Dict{ParameterOrExtra{<:TKey},SizedMatrix{NIter1 + NIter2,NChains}}()
     for k in union(keys(c1), keys(c2))
-        c1_data = if haskey(c1, k)
-            c1[k]
-        else
-            SizedMatrix{NIter1,NChains}(fill(missing, NIter1, NChains))
-        end
-        c2_data = if haskey(c2, k)
-            c2[k]
-        else
-            SizedMatrix{NIter2,NChains}(fill(missing, NIter2, NChains))
-        end
+        c1_data = haskey(c1, k) ? c1._data[k] : fill(missing, NIter1, NChains)
+        c2_data = haskey(c2, k) ? c2._data[k] : fill(missing, NIter2, NChains)
         d[k] = SizedMatrix{NIter1 + NIter2,NChains}(vcat(c1_data, c2_data))
     end
     return FlexiChain{TKey,NIter1 + NIter2,NChains}(
@@ -403,22 +395,15 @@ function Base.hcat(
 )::FlexiChain{TKey,NIter,NChains1 + NChains2} where {TKey,NIter,NChains1,NChains2}
     d = Dict{ParameterOrExtra{<:TKey},SizedMatrix{NIter,NChains1 + NChains2}}()
     for k in union(keys(c1), keys(c2))
-        c1_data = if haskey(c1, k)
-            c1[k]
-        else
-            SizedMatrix{NIter,NChains1}(fill(missing, NIter, NChains1))
-        end
-        c2_data = if haskey(c2, k)
-            c2[k]
-        else
-            SizedMatrix{NIter,NChains2}(fill(missing, NIter, NChains2))
-        end
+        c1_data = haskey(c1, k) ? c1._data[k] : fill(missing, NIter, NChains1)
+        c2_data = haskey(c2, k) ? c2._data[k] : fill(missing, NIter, NChains2)
         d[k] = SizedMatrix{NIter,NChains1 + NChains2}(hcat(c1_data, c2_data))
     end
+    # Calculate sensible chain indices
     return FlexiChain{TKey,NIter,NChains1 + NChains2}(
         d;
         iter_indices=FlexiChains.iter_indices(c1),
-        chain_indices=vcat(FlexiChains.chain_indices(c1), FlexiChains.chain_indices(c2)),
+        chain_indices=1:(NChains1 + NChains2),
         sampling_time=vcat(FlexiChains.sampling_time(c1), FlexiChains.sampling_time(c2)),
         last_sampler_state=vcat(
             FlexiChains.last_sampler_state(c1), FlexiChains.last_sampler_state(c2)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,3 +1,5 @@
+using DimensionalData: DimensionalData as DD
+
 @public niters, nchains
 @public subset, subset_parameters, subset_extras
 @public parameters, extras, extras_grouped
@@ -216,12 +218,12 @@ end
 function Base.show(
     io::IO, ::MIME"text/plain", chain::FlexiChain{TKey,niters,nchains}
 ) where {TKey,niters,nchains}
-    printstyled(
-        io,
-        "FlexiChain ($niters iterations, $nchains chain$(nchains > 1 ? "s" : ""))\n\n";
-        bold=true,
-    )
-
+    maybe_s(x) = x == 1 ? "" : "s"
+    printstyled(io, "FlexiChain | $niters iteration$(maybe_s(niters)) ("; bold=true)
+    printstyled(io, "$(FlexiChains.iter_indices(chain))"; color=DD.dimcolor(1), bold=true)
+    printstyled(io, ") | $nchains chain$(maybe_s(nchains)) ("; bold=true)
+    printstyled(io, "$(FlexiChains.chain_indices(chain))"; color=DD.dimcolor(2), bold=true)
+    printstyled(io, ")\n"; bold=true)
     # Print parameter names
     parameter_names = parameters(chain)
     printstyled(io, "Parameter type   "; bold=true)
@@ -235,7 +237,7 @@ function Base.show(
 
     # Print extras
     extras = extras_grouped(chain)
-    printstyled(io, "Other keys       "; bold=true)
+    printstyled(io, "Extra keys       "; bold=true)
     if isempty(extras)
         println(io, "(none)")
     else

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -134,7 +134,7 @@ function Base.merge(
     d1 = Dict{ParameterOrExtra{TKeyNew},SizedMatrix{NIter,NChain,<:TValNew}}(c1._data)
     d2 = Dict{ParameterOrExtra{TKeyNew},SizedMatrix{NIter,NChain,<:TValNew}}(c2._data)
     merged_data = merge(d1, d2)
-    return FlexiChain{TKeyNew}(merged_data)
+    return FlexiChain{TKeyNew,NIter,NChain}(merged_data)
 end
 function Base.merge(
     ::FlexiChain{TKey1,NIter1,NChain1}, ::FlexiChain{TKey2,NIter2,NChain2}
@@ -338,7 +338,7 @@ function Base.vcat(
         end
         d[k] = SizedMatrix{NIter1 + NIter2,NChains}(vcat(c1_data, c2_data))
     end
-    return FlexiChain{TKey}(d)
+    return FlexiChain{TKey,NIter1 + NIter2,NChains}(d)
 end
 function Base.vcat(c1::FlexiChain{TKey}, c2::FlexiChain{TKey}) where {TKey}
     throw(
@@ -395,7 +395,7 @@ function Base.hcat(
     last_sampler_states = vcat(
         FlexiChains.last_sampler_state(c1), FlexiChains.last_sampler_state(c2)
     )
-    return FlexiChain{TKey}(
+    return FlexiChain{TKey,NIter,NChains1 + NChains2}(
         d; sampling_time=sampling_times, last_sampler_state=last_sampler_states
     )
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -116,10 +116,8 @@ and a warning will be issued.
 
 The two `FlexiChain`s being merged must have the same dimensions.
 
-The chain indices and metadata are taken from the first chain. Those in the second chain are
+The chain indices and metadata are taken from the second chain. Those in the first chain are
 silently ignored.
-
-Note that this function does not perform a deepcopy of the underlying data.
 """
 function Base.merge(
     c1::FlexiChain{TKey1,NIter,NChain}, c2::FlexiChain{TKey2,NIter,NChain}
@@ -141,10 +139,10 @@ function Base.merge(
     merged_data = merge(d1, d2)
     return FlexiChain{TKeyNew,NIter,NChain}(
         merged_data;
-        iter_indices=FlexiChains.iter_indices(c1),
-        chain_indices=FlexiChains.chain_indices(c1),
-        sampling_time=FlexiChains.sampling_time(c1),
-        last_sampler_state=FlexiChains.last_sampler_state(c1),
+        iter_indices=FlexiChains.iter_indices(c2),
+        chain_indices=FlexiChains.chain_indices(c2),
+        sampling_time=FlexiChains.sampling_time(c2),
+        last_sampler_state=FlexiChains.last_sampler_state(c2),
     )
 end
 function Base.merge(
@@ -166,8 +164,6 @@ end
 
 Create a new `FlexiChain` containing only the specified keys and the data corresponding to
 them.
-
-Note that this function does not perform a deepcopy of the underlying data.
 """
 function subset(
     chain::FlexiChain{TKey,NIter,NChain}, keys::AbstractVector{<:ParameterOrExtra{<:TKey}}
@@ -186,7 +182,7 @@ function subset(
 end
 
 """
-    subset_parameters(chain::FlexiChain{TKey,NIter,NChain})
+    subset_parameters(chain::FlexiChain)
 
 Subset a chain, retaining only the `Parameter` keys.
 """

--- a/src/sizedmatrix.jl
+++ b/src/sizedmatrix.jl
@@ -49,7 +49,7 @@ end
         chain_indices=1:NChains
     ) where {NIter,NChains,T}
 
-Return the underlying data of a `SizedMatrix` as a [`DimensionalData.DimMatrix`](@extref).
+Return the underlying data of a `SizedMatrix` as a [`DimensionalData.DimMatrix`](@extref DimensionalData DimArrays).
 
 The returned `DimMatrix` has dimensions named `:iter` and `:chain`. By default the indices
 along both dimensions simply count upwards from 1. You can override this by passing in

--- a/src/sizedmatrix.jl
+++ b/src/sizedmatrix.jl
@@ -1,5 +1,6 @@
 using DimensionalData: DimensionalData as DD
 using DimensionalData.Dimensions.Lookups: Sampled
+using DimensionalData.Dimensions: AnonDim
 const ITER_DIM_NAME = :iter
 const CHAIN_DIM_NAME = :chain
 
@@ -63,6 +64,14 @@ function data(
         s._data,
         (DD.Dim{ITER_DIM_NAME}(iter_indices), DD.Dim{CHAIN_DIM_NAME}(chain_indices)),
     )
+end
+function data_anon_iter(
+    s::SizedMatrix{1,NChains,T}; chain_indices=1:NChains
+) where {NChains,T}
+    return DD.DimMatrix(s._data, (AnonDim(), DD.Dim{CHAIN_DIM_NAME}(chain_indices)))
+end
+function data_anon_chain(s::SizedMatrix{NIter,1,T}; iter_indices=1:NIter) where {NIter,T}
+    return DD.DimMatrix(s._data, (DD.Dim{ITER_DIM_NAME}(iter_indices), AnonDim()))
 end
 
 function Base.collect(

--- a/src/sizedmatrix.jl
+++ b/src/sizedmatrix.jl
@@ -1,57 +1,68 @@
-"""
-    SizedMatrix{NIter,NChains,T}
+using DimensionalData: DimensionalData as DD
+using DimensionalData.Dimensions.Lookups: Sampled
+const ITER_DIM_NAME = :iter
+const CHAIN_DIM_NAME = :chain
 
-A matrix type that is used to store the data in a `FlexiChain`. It is similar
-to `StaticArrays.SMatrix` in terms of its type behaviour, but under the hood
-uses plain `Array`s for storage. This allows us to have type-level guarantees
-about the size of the matrix, without having to opt into the performance
-characteristics and data structures of `StaticArrays`.
+"""
+    SizedMatrix{NIter,NChain,T} <: AbstractMatrix
+
+A matrix type that is used to store the data in a [`FlexiChain`](@ref). It is just a plain
+wrapper type, but with type parameters for the number of iterations and chains. This allows
+us to have type-level guarantees about the size of the matrix.
 
 `T` is the element type.
 
-The underlying data in a SizedMatrix can be accessed using
-`data(::SizedMatrix)`. If the matrix has only one chain, it will be
-returned as a vector. If it has multiple chains, it will be returned as a
-matrix.
+!!! warning
+    Note that this is not part of FlexiChains's public API. Use this at your own risk.
 
 ## Fields
 
 $(TYPEDFIELDS)
 """
-struct SizedMatrix{NIter,NChains,T} <: AbstractArray{T,2}
+struct SizedMatrix{NIter,NChain,T} <: AbstractArray{T,2}
     """
-    Internal data. Do not access this directly! Use `data(::SizedMatrix)` instead.
+    Internal data.
     """
-    _data::Matrix{T}
+    _data::AbstractMatrix{T}
 
-    function SizedMatrix{NIter,NChains}(data::AbstractMatrix{T}) where {NIter,NChains,T}
-        if size(data) != (NIter, NChains)
-            msg = "expected matrix of size ($(NIter), $(NChains)), got $(size(data))."
+    function SizedMatrix{NIter,NChain}(data::AbstractMatrix{T}) where {NIter,NChain,T}
+        if size(data) != (NIter, NChain)
+            msg = "expected matrix of size ($(NIter), $(NChain)), got $(size(data))."
             throw(DimensionMismatch(msg))
         end
-        return new{NIter,NChains,T}(collect(T, data))
+        return new{NIter,NChain,T}(collect(T, data))
     end
     function SizedMatrix{NIter,1}(data::AbstractVector{T}) where {NIter,T}
         if length(data) != (NIter)
             msg = "expected vector of length $(NIter), got $(length(data))."
             throw(DimensionMismatch(msg))
         end
-        return new{NIter,1,T}(reshape(data, NIter, 1)) # convert vector to matrix.
+        data = reshape(collect(T, data), NIter, 1) # Convert to matrix
+        return new{NIter,1,T}(data)
     end
 end
 """
-    data(s::SizedMatrix{NIter,NChains,T}) where {NIter,NChains,T}
+    data(
+        s::SizedMatrix{NIter,NChains,T};
+        iter_indices=1:NIter,
+        chain_indices=1:NChains
+    ) where {NIter,NChains,T}
 
-Return the underlying data of a `SizedMatrix` as a matrix, or a vector if
-`NChains` is 1.
+Return the underlying data of a `SizedMatrix` as a [`DimensionalData.DimMatrix`](@extref).
 
-Note that this differs from `Base.collect`, which always returns a matrix.
+The returned `DimMatrix` has dimensions named `:iter` and `:chain`. By default the indices
+along both dimensions simply count upwards from 1. You can override this by passing in
+custom `iter_indices` and `chain_indices` keyword arguments.
+
+Note that this differs from `Base.collect`, which always returns a plain `Matrix`.
 """
-function data(s::SizedMatrix{NIter,NChains,T}) where {NIter,NChains,T}
-    return s._data
-end
-function data(s::SizedMatrix{NIter,1,T}) where {NIter,T}
-    return vec(s._data)
+function data(
+    s::SizedMatrix{NIter,NChains,T}; iter_indices=1:NIter, chain_indices=1:NChains
+) where {NIter,NChains,T}
+    return DD.DimMatrix(
+        s._data,
+        (DD.Dim{ITER_DIM_NAME}(iter_indices), DD.Dim{CHAIN_DIM_NAME}(chain_indices)),
+    )
 end
 
 function Base.collect(
@@ -70,13 +81,9 @@ function Base.getindex(
 ) where {NIter,NChains,T}
     return s._data[i, j]
 end
-function Base.getindex(s::SizedMatrix{NIter,1,T}, i::Int) where {NIter,T}
-    return s._data[i, 1]
-end
 function Base.convert(
     ::Type{SizedMatrix{NIter,NChains,Tdst}}, s::SizedMatrix{NIter,NChains,Tsrc}
 ) where {NIter,NChains,Tsrc,Tdst}
-    Tsrc <: Tdst && return s
     # collect() will error if it can't be casted
-    return SizedMatrix{NIter,NChains}(collect(Tdst, s))
+    return SizedMatrix{NIter,NChains,Tdst}(collect(Tdst, s))
 end

--- a/src/summaries.jl
+++ b/src/summaries.jl
@@ -5,7 +5,7 @@ using Statistics: Statistics
 abstract type FlexiChainSummary{TKey,NIter,NChains} end
 
 """
-    FlexiChainSummaryI{TKey,NIter,NChains}
+    FlexiChainSummaryI{TKey,NIter,NChains,TCIdx<:AbstractVector{Int}}
 
 A summary where the iteration dimension has been collapsed. The type parameter `NIter`
 refers to the original number of iterations (which have been collapsed).
@@ -13,14 +13,30 @@ refers to the original number of iterations (which have been collapsed).
 If NChains > 1, indexing into this returns a (1 × NChains) matrix for each key; otherwise
 it returns a scalar.
 """
-struct FlexiChainSummaryI{TKey,NIter,NChains} <: FlexiChainSummary{TKey,NIter,NChains}
+struct FlexiChainSummaryI{TKey,NIter,NChains,TCIdx<:AbstractVector{Int}} <:
+       FlexiChainSummary{TKey,NIter,NChains}
     _data::Dict{<:ParameterOrExtra{TKey},<:SizedMatrix{1,NChains,<:Any}}
+    _chain_indices::TCIdx
+
+    # Constructor checks that `chain_indices` has the right length.
+    function FlexiChainSummaryI{TKey,NIter,NChains}(
+        data::Dict{<:ParameterOrExtra{TKey},<:SizedMatrix{1,NChains,<:Any}},
+        chain_indices::TCIdx,
+    ) where {TKey,NIter,NChains,TCIdx<:AbstractVector{Int}}
+        if length(chain_indices) != NChains
+            throw(DimensionMismatch("`chain_indices` must have length $NChains"))
+        end
+        return new{TKey,NIter,NChains,typeof(chain_indices)}(data, chain_indices)
+    end
 end
-_get(fcsi::FlexiChainSummaryI{T,Ni,Nc}, key) where {T,Ni,Nc} = collect(fcsi._data[key]) # matrix
-_get(fcsi::FlexiChainSummaryI{T,Ni,1}, key) where {T,Ni} = only(collect(fcsi._data[key])) # scalar
+function FlexiChains.chain_indices(
+    fcsi::FlexiChainSummaryI{T,NI,NC,TCIdx}
+) where {T,NI,NC,TCIdx}
+    return fcsi._chain_indices
+end
 
 """
-    FlexiChainSummaryC{TKey,NIter,NChains}
+    FlexiChainSummaryC{TKey,NIter,NChains,TIIdx<:AbstractVector{Int}}
 
 A summary where the chain dimension has been collapsed. The type parameter `NChain` refers to
 the original number of chains (which have been collapsed).
@@ -28,11 +44,27 @@ the original number of chains (which have been collapsed).
 If NChains > 1, indexing into this returns a (NIter × 1) matrix for each key; otherwise it
 returns a vector.
 """
-struct FlexiChainSummaryC{TKey,NIter,NChains} <: FlexiChainSummary{TKey,NIter,NChains}
+struct FlexiChainSummaryC{TKey,NIter,NChains,TIIdx<:AbstractVector{Int}} <:
+       FlexiChainSummary{TKey,NIter,NChains}
     _data::Dict{<:ParameterOrExtra{TKey},<:SizedMatrix{NIter,1,<:Any}}
+    _iter_indices::TIIdx
+
+    # Constructor checks that `iter_indices` has the right length.
+    function FlexiChainSummaryC{TKey,NIter,NChains}(
+        data::Dict{<:ParameterOrExtra{TKey},<:SizedMatrix{NIter,1,<:Any}},
+        iter_indices::TIIdx,
+    ) where {TKey,NIter,NChains,TIIdx<:AbstractVector{Int}}
+        if length(iter_indices) != NIter
+            throw(DimensionMismatch("`iter_indices` must have length $NIter"))
+        end
+        return new{TKey,NIter,NChains,typeof(iter_indices)}(data, iter_indices)
+    end
 end
-_get(fcsc::FlexiChainSummaryC{T,N,M}, key) where {T,N,M} = collect(fcsc._data[key]) # matrix
-_get(fcsc::FlexiChainSummaryC{T,N,1}, key) where {T,N} = data(fcsc._data[key]) # vector
+function FlexiChains.iter_indices(
+    fcsc::FlexiChainSummaryC{T,NI,NC,TIIdx}
+) where {T,NI,NC,TIIdx}
+    return fcsc._iter_indices
+end
 
 """
     FlexiChainSummaryIC{TKey,NIter,NChains}
@@ -103,7 +135,7 @@ function collapse_iter(
         end
     end
     warn && _warn_non_numerics(non_numerics)
-    return FlexiChainSummaryI{TKey,NIter,NChains}(data)
+    return FlexiChainSummaryI{TKey,NIter,NChains}(data, FlexiChains.chain_indices(chain))
 end
 
 """
@@ -148,8 +180,6 @@ function collapse_chain(
     non_numerics = ParameterOrExtra{TKey}[]
     for (k, v) in chain._data
         if (!skip_nonnumeric) || eltype(v) <: Number
-            # We use chain._data[k] instead of chain[k] here to guarantee that the input to
-            # `k` is always a matrix (if NChains=1, chain[k] would return a vector).
             collapsed = func(chain._data[k]; kwargs...)
             data[k] = SizedMatrix{NIter,1}(collapsed)
         else
@@ -157,7 +187,7 @@ function collapse_chain(
         end
     end
     warn && _warn_non_numerics(non_numerics)
-    return FlexiChainSummaryC{TKey,NIter,NChains}(data)
+    return FlexiChainSummaryC{TKey,NIter,NChains}(data, FlexiChains.iter_indices(chain))
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -23,9 +23,15 @@ using Test
 
                 @testset "with metadata" begin
                     chain2 = FlexiChain{Symbol,N_iters,1}(
-                        dicts; sampling_time=1, last_sampler_state="foo"
+                        dicts;
+                        iter_indices=3:3:(3 * N_iters),
+                        chain_indices=[2],
+                        sampling_time=1,
+                        last_sampler_state="foo",
                     )
                     @test size(chain2) == (N_iters, 1)
+                    @test FlexiChains.iter_indices(chain2) == 3:3:(3 * N_iters)
+                    @test FlexiChains.chain_indices(chain2) == [2]
                     @test FlexiChains.sampling_time(chain2) == [1]
                     @test FlexiChains.last_sampler_state(chain2) == ["foo"]
                 end
@@ -56,9 +62,15 @@ using Test
 
                 @testset "with metadata" begin
                     chain2 = FlexiChain{Symbol,N_iters,N_chains}(
-                        dicts; sampling_time=[1, 2], last_sampler_state=["foo", "bar"]
+                        dicts;
+                        iter_indices=3:3:(3 * N_iters),
+                        chain_indices=[2, 1],
+                        sampling_time=[1, 2],
+                        last_sampler_state=["foo", "bar"],
                     )
                     @test size(chain2) == (N_iters, N_chains)
+                    @test FlexiChains.iter_indices(chain2) == 3:3:(3 * N_iters)
+                    @test FlexiChains.chain_indices(chain2) == [2, 1]
                     @test FlexiChains.sampling_time(chain2) == [1, 2]
                     @test FlexiChains.last_sampler_state(chain2) == ["foo", "bar"]
                 end
@@ -93,9 +105,15 @@ using Test
 
                 @testset "with metadata" begin
                     chain2 = FlexiChain{Symbol,N_iters,1}(
-                        arrays; sampling_time=1, last_sampler_state="foo"
+                        arrays;
+                        iter_indices=3:3:(3 * N_iters),
+                        chain_indices=[2],
+                        sampling_time=1,
+                        last_sampler_state="foo",
                     )
                     @test size(chain2) == (N_iters, 1)
+                    @test FlexiChains.iter_indices(chain2) == 3:3:(3 * N_iters)
+                    @test FlexiChains.chain_indices(chain2) == [2]
                     @test FlexiChains.sampling_time(chain2) == [1]
                     @test FlexiChains.last_sampler_state(chain2) == ["foo"]
                 end
@@ -113,18 +131,24 @@ using Test
 
                 @testset "wrong indices length" begin
                     @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
-                        dicts; iter_indices=1:(2 * N_iters)
+                        arrays; iter_indices=1:(2 * N_iters)
                     )
                     @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
-                        dicts; chain_indices=1:(2 * N_chains)
+                        arrays; chain_indices=1:(2 * N_chains)
                     )
                 end
 
                 @testset "with metadata" begin
                     chain2 = FlexiChain{Symbol,N_iters,N_chains}(
-                        arrays; sampling_time=[1, 2], last_sampler_state=["foo", "bar"]
+                        arrays;
+                        iter_indices=3:3:(3 * N_iters),
+                        chain_indices=[2, 1],
+                        sampling_time=[1, 2],
+                        last_sampler_state=["foo", "bar"],
                     )
                     @test size(chain2) == (N_iters, N_chains)
+                    @test FlexiChains.iter_indices(chain2) == 3:3:(3 * N_iters)
+                    @test FlexiChains.chain_indices(chain2) == [2, 1]
                     @test FlexiChains.sampling_time(chain2) == [1, 2]
                     @test FlexiChains.last_sampler_state(chain2) == ["foo", "bar"]
                 end

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -171,21 +171,23 @@ using Test
         end
     end
 
-    @testset "renumber_iter and renumber_chain" begin
+    @testset "renumber_iters and renumber_chains" begin
         N_iters, N_chains = 10, 2
         dicts = fill(Dict(Parameter(:a) => 1), N_iters, N_chains)
         chain = FlexiChain{Symbol,N_iters,N_chains}(dicts)
-        @testset "renumber_iter" begin
+        @testset "renumber_iters" begin
             new_iters = 3:3:(3 * N_iters)
-            chain2 = @inferred FlexiChains.renumber_iter(chain, new_iters)
+            chain2 = @inferred FlexiChains.renumber_iters(chain, new_iters)
             @test FlexiChains.iter_indices(chain2) == new_iters
-            @test_throws DimensionMismatch FlexiChains.renumber_iter(chain, 1:(2 * N_iters))
+            @test_throws DimensionMismatch FlexiChains.renumber_iters(
+                chain, 1:(2 * N_iters)
+            )
         end
-        @testset "renumber_chain" begin
+        @testset "renumber_chains" begin
             new_chains = [2, 1]
-            chain2 = @inferred FlexiChains.renumber_chain(chain, new_chains)
+            chain2 = @inferred FlexiChains.renumber_chains(chain, new_chains)
             @test FlexiChains.chain_indices(chain2) == new_chains
-            @test_throws DimensionMismatch FlexiChains.renumber_chain(
+            @test_throws DimensionMismatch FlexiChains.renumber_chains(
                 chain, 1:(2 * N_chains)
             )
         end

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -18,11 +18,11 @@ using Test
                     ),
                     N_iters,
                 )
-                chain = FlexiChain{Symbol}(dicts)
+                chain = FlexiChain{Symbol,N_iters,1}(dicts)
                 @test size(chain) == (N_iters, 1)
 
                 @testset "with metadata" begin
-                    chain2 = FlexiChain{Symbol}(
+                    chain2 = FlexiChain{Symbol,N_iters,1}(
                         dicts; sampling_time=1, last_sampler_state="foo"
                     )
                     @test size(chain2) == (N_iters, 1)
@@ -42,11 +42,11 @@ using Test
                     N_iters,
                     N_chains,
                 )
-                chain = FlexiChain{Symbol}(dicts)
+                chain = FlexiChain{Symbol,N_iters,N_chains}(dicts)
                 @test size(chain) == (N_iters, N_chains)
 
                 @testset "with metadata" begin
-                    chain2 = FlexiChain{Symbol}(
+                    chain2 = FlexiChain{Symbol,N_iters,N_chains}(
                         dicts; sampling_time=[1, 2], last_sampler_state=["foo", "bar"]
                     )
                     @test size(chain2) == (N_iters, N_chains)
@@ -55,16 +55,16 @@ using Test
                 end
 
                 @testset "wrong metadata size" begin
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         dicts; sampling_time=1
                     )
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         dicts; sampling_time=1:3
                     )
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         dicts; last_sampler_state="foo"
                     )
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         dicts; last_sampler_state=["foo", "bar", "baz"]
                     )
                 end
@@ -79,11 +79,11 @@ using Test
                     Parameter(:b) => rand(N_iters),
                     Extra(:section, "hello") => rand(N_iters),
                 )
-                chain = FlexiChain{Symbol}(arrays)
+                chain = FlexiChain{Symbol,N_iters,1}(arrays)
                 @test size(chain) == (N_iters, 1)
 
                 @testset "with metadata" begin
-                    chain2 = FlexiChain{Symbol}(
+                    chain2 = FlexiChain{Symbol,N_iters,1}(
                         arrays; sampling_time=1, last_sampler_state="foo"
                     )
                     @test size(chain2) == (N_iters, 1)
@@ -99,11 +99,11 @@ using Test
                     Parameter(:b) => rand(N_iters, N_chains),
                     Extra(:section, "hello") => rand(N_iters, N_chains),
                 )
-                chain = FlexiChain{Symbol}(arrays)
+                chain = FlexiChain{Symbol,N_iters,N_chains}(arrays)
                 @test size(chain) == (N_iters, N_chains)
 
                 @testset "with metadata" begin
-                    chain2 = FlexiChain{Symbol}(
+                    chain2 = FlexiChain{Symbol,N_iters,N_chains}(
                         arrays; sampling_time=[1, 2], last_sampler_state=["foo", "bar"]
                     )
                     @test size(chain2) == (N_iters, N_chains)
@@ -112,16 +112,16 @@ using Test
                 end
 
                 @testset "wrong metadata size" begin
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         arrays; sampling_time=1
                     )
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         arrays; sampling_time=1:3
                     )
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         arrays; last_sampler_state="foo"
                     )
-                    @test_throws DimensionMismatch FlexiChain{Symbol}(
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
                         arrays; last_sampler_state=["foo", "bar", "baz"]
                     )
                 end

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -45,6 +45,15 @@ using Test
                 chain = FlexiChain{Symbol,N_iters,N_chains}(dicts)
                 @test size(chain) == (N_iters, N_chains)
 
+                @testset "wrong indices length" begin
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
+                        dicts; iter_indices=1:(2 * N_iters)
+                    )
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
+                        dicts; chain_indices=1:(2 * N_chains)
+                    )
+                end
+
                 @testset "with metadata" begin
                     chain2 = FlexiChain{Symbol,N_iters,N_chains}(
                         dicts; sampling_time=[1, 2], last_sampler_state=["foo", "bar"]
@@ -101,6 +110,15 @@ using Test
                 )
                 chain = FlexiChain{Symbol,N_iters,N_chains}(arrays)
                 @test size(chain) == (N_iters, N_chains)
+
+                @testset "wrong indices length" begin
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
+                        dicts; iter_indices=1:(2 * N_iters)
+                    )
+                    @test_throws DimensionMismatch FlexiChain{Symbol,N_iters,N_chains}(
+                        dicts; chain_indices=1:(2 * N_chains)
+                    )
+                end
 
                 @testset "with metadata" begin
                     chain2 = FlexiChain{Symbol,N_iters,N_chains}(

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -26,8 +26,8 @@ using Test
                         dicts; sampling_time=1, last_sampler_state="foo"
                     )
                     @test size(chain2) == (N_iters, 1)
-                    @test FlexiChains.sampling_time(chain2) == 1
-                    @test FlexiChains.last_sampler_state(chain2) == "foo"
+                    @test FlexiChains.sampling_time(chain2) == [1]
+                    @test FlexiChains.last_sampler_state(chain2) == ["foo"]
                 end
             end
 
@@ -87,8 +87,8 @@ using Test
                         arrays; sampling_time=1, last_sampler_state="foo"
                     )
                     @test size(chain2) == (N_iters, 1)
-                    @test FlexiChains.sampling_time(chain2) == 1
-                    @test FlexiChains.last_sampler_state(chain2) == "foo"
+                    @test FlexiChains.sampling_time(chain2) == [1]
+                    @test FlexiChains.last_sampler_state(chain2) == ["foo"]
                 end
             end
 

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -170,6 +170,26 @@ using Test
             end
         end
     end
+
+    @testset "renumber_iter and renumber_chain" begin
+        N_iters, N_chains = 10, 2
+        dicts = fill(Dict(Parameter(:a) => 1), N_iters, N_chains)
+        chain = FlexiChain{Symbol,N_iters,N_chains}(dicts)
+        @testset "renumber_iter" begin
+            new_iters = 3:3:(3 * N_iters)
+            chain2 = @inferred FlexiChains.renumber_iter(chain, new_iters)
+            @test FlexiChains.iter_indices(chain2) == new_iters
+            @test_throws DimensionMismatch FlexiChains.renumber_iter(chain, 1:(2 * N_iters))
+        end
+        @testset "renumber_chain" begin
+            new_chains = [2, 1]
+            chain2 = @inferred FlexiChains.renumber_chain(chain, new_chains)
+            @test FlexiChains.chain_indices(chain2) == new_chains
+            @test_throws DimensionMismatch FlexiChains.renumber_chain(
+                chain, 1:(2 * N_chains)
+            )
+        end
+    end
 end
 
 end # module

--- a/test/ext/turing.jl
+++ b/test/ext/turing.jl
@@ -150,7 +150,7 @@ Turing.setprogress!(false)
 
             @testset "single chain" begin
                 chn = sample(model, NUTS(), 100; chain_type=VNChain, verbose=false)
-                @test FlexiChains.sampling_time(chn) isa AbstractFloat
+                @test only(FlexiChains.sampling_time(chn)) isa AbstractFloat
             end
             @testset "multiple chain" begin
                 chn = sample(
@@ -192,7 +192,7 @@ Turing.setprogress!(false)
                     save_state=true,
                 )
                 # check that the sampler state is stored
-                @test FlexiChains.last_sampler_state(chn1) isa DynamicPPL.VarInfo
+                @test only(FlexiChains.last_sampler_state(chn1)) isa DynamicPPL.VarInfo
                 # check that it can be resumed from
                 chn2 = sample(
                     model,

--- a/test/ext/turing.jl
+++ b/test/ext/turing.jl
@@ -1,6 +1,7 @@
 module FCTuringExtTests
 
 using AbstractMCMC: AbstractMCMC
+using DimensionalData: DimensionalData as DD
 using DynamicPPL: DynamicPPL
 using FlexiChains: FlexiChains, VNChain, Parameter, Extra
 using MCMCChains: MCMCChains
@@ -254,14 +255,20 @@ Turing.setprogress!(false)
         @testset "logprior" begin
             lprior = logprior(model, chn)
             @test isapprox(lprior, expected_logprior)
+            @test parent(parent(DD.dims(lprior, :iter))) == FlexiChains.iter_indices(chn)
+            @test parent(parent(DD.dims(lprior, :chain))) == FlexiChains.chain_indices(chn)
         end
         @testset "loglikelihood" begin
             llike = loglikelihood(model, chn)
             @test isapprox(llike, expected_loglike)
+            @test parent(parent(DD.dims(llike, :iter))) == FlexiChains.iter_indices(chn)
+            @test parent(parent(DD.dims(llike, :chain))) == FlexiChains.chain_indices(chn)
         end
         @testset "logjoint" begin
             ljoint = logjoint(model, chn)
             @test isapprox(ljoint, expected_logprior .+ expected_loglike)
+            @test parent(parent(DD.dims(ljoint, :iter))) == FlexiChains.iter_indices(chn)
+            @test parent(parent(DD.dims(ljoint, :chain))) == FlexiChains.chain_indices(chn)
         end
     end
 
@@ -275,6 +282,9 @@ Turing.setprogress!(false)
         expected_rtnd = chn[:x] .+ 1
         rtnd = returned(model, chn)
         @test isapprox(rtnd, expected_rtnd)
+        @test rtnd isa DD.DimMatrix
+        @test parent(parent(DD.dims(rtnd, :iter))) == FlexiChains.iter_indices(chn)
+        @test parent(parent(DD.dims(rtnd, :chain))) == FlexiChains.chain_indices(chn)
     end
 
     @testset "predict" begin

--- a/test/ext/turing.jl
+++ b/test/ext/turing.jl
@@ -331,6 +331,16 @@ Turing.setprogress!(false)
             @test isempty(setdiff(Set(keys(chn)), Set(keys(pdns))))
         end
 
+        @testset "metadata is preserved" begin
+            chn = sample(model, NUTS(), 100; chain_type=VNChain, verbose=false)
+            pdns = predict(f(), chn)
+            @test FlexiChains.iter_indices(pdns) == FlexiChains.iter_indices(chn)
+            @test FlexiChains.chain_indices(pdns) == FlexiChains.chain_indices(chn)
+            @test FlexiChains.sampling_time(pdns) == FlexiChains.sampling_time(chn)
+            @test FlexiChains.last_sampler_state(pdns) ==
+                FlexiChains.last_sampler_state(chn)
+        end
+
         @testset "rng is respected" begin
             pdns1 = predict(Xoshiro(468), f(), chn)
             pdns2 = predict(Xoshiro(468), f(), chn)

--- a/test/ext/turing.jl
+++ b/test/ext/turing.jl
@@ -360,6 +360,11 @@ Turing.setprogress!(false)
                 @test new_mcmcc[k] == mcmcc[k]
             end
         end
+
+        @testset "iteration indices" begin
+            @test FlexiChains.iter_indices(flexic) == range(new_mcmcc)
+        end
+
         @testset "grouping of data into sections" begin
             @test Set(keys(new_mcmcc.name_map)) == Set(keys(mcmcc.name_map))
             for k in keys(new_mcmcc.name_map)

--- a/test/ext/turing.jl
+++ b/test/ext/turing.jl
@@ -363,6 +363,7 @@ Turing.setprogress!(false)
 
         @testset "iteration indices" begin
             @test FlexiChains.iter_indices(flexic) == range(new_mcmcc)
+            @test range(new_mcmcc) == range(mcmcc)
         end
 
         @testset "grouping of data into sections" begin

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,6 +1,7 @@
 module FCInterfaceTests
 
 using FlexiChains: FlexiChains, FlexiChain, Parameter, Extra, @varname, VarName
+using DimensionalData: DimensionalData as DD
 using AbstractMCMC: AbstractMCMC
 using Test
 
@@ -9,8 +10,8 @@ using Test
 
     @testset "equality" begin
         d = Dict(Parameter(:a) => 1, Extra(:section, "hello") => 3.0)
-        chain1 = FlexiChain{Symbol}(fill(d, 10))
-        chain2 = FlexiChain{Symbol}(fill(d, 10))
+        chain1 = FlexiChain{Symbol,10,1}(fill(d, 10))
+        chain2 = FlexiChain{Symbol,10,1}(fill(d, 10))
         @test chain1 == chain2
     end
 
@@ -18,7 +19,7 @@ using Test
         N_iters, N_chains = 10, 2
         d = Dict(Parameter(:a) => 1, Parameter(:b) => 2, Extra(:section, "hello") => 3.0)
         dicts = fill(d, N_iters, N_chains)
-        chain = FlexiChain{Symbol}(dicts)
+        chain = FlexiChain{Symbol,N_iters,N_chains}(dicts)
         # size
         @test chain isa FlexiChain{Symbol,N_iters,N_chains}
         @test size(chain) == (N_iters, N_chains)
@@ -42,7 +43,7 @@ using Test
             Extra(:section, "world") => 4.0,
             Extra(:other, "key") => 5.0,
         )
-        chain = FlexiChain{Symbol}(fill(d, N_iters))
+        chain = FlexiChain{Symbol,N_iters,1}(fill(d, N_iters))
 
         @testset "parameters" begin
             @test Set(FlexiChains.parameters(chain)) == Set([:a, :b])
@@ -62,6 +63,22 @@ using Test
     end
 
     @testset "getindex" begin
+        @testset "DimArray is correctly constructed" begin
+            N_iters = 10
+            dicts = fill(Dict(Parameter(:a) => 1), N_iters)
+            # Inject some chaos with non-default iter_indices and chain_indices
+            chain = FlexiChain{Symbol,N_iters,1}(
+                dicts; iter_indices=3:3:(N_iters * 3), chain_indices=[4]
+            )
+
+            returned_as = chain[Parameter(:a)]
+            @test returned_as isa DD.DimMatrix
+            @test size(returned_as) == (N_iters, 1)
+            @test DD.dims(returned_as) isa Tuple{DD.Dim{:iter},DD.Dim{:chain}}
+            @test parent(DD.val(DD.dims(returned_as), :iter)) == 3:3:(N_iters * 3)
+            @test parent(DD.val(DD.dims(returned_as), :chain)) == [4]
+        end
+
         @testset "unambiguous getindex" begin
             N_iters = 10
             dicts = fill(
@@ -70,19 +87,24 @@ using Test
                 ),
                 N_iters,
             )
-            chain = FlexiChain{Symbol}(dicts)
+            chain = FlexiChain{Symbol,N_iters,1}(dicts)
+
+            # Note that DimArrays compare equal to regular matrices with `==` if they have
+            # the same contents, so these tests don't actually check that the types returned
+            # are correct.
 
             # getindex directly with key
-            @test chain[Parameter(:a)] == fill(1, N_iters)
-            @test chain[Parameter(:b)] == fill(2, N_iters)
-            @test chain[Extra(:section, "hello")] == fill(3.0, N_iters)
+            @test chain[Parameter(:a)] == fill(1, N_iters, 1)
+            @test chain[Parameter(:a)] == fill(1, N_iters, 1)
+            @test chain[Parameter(:b)] == fill(2, N_iters, 1)
+            @test chain[Extra(:section, "hello")] == fill(3.0, N_iters, 1)
             @test_throws KeyError chain[Parameter(:c)]
             @test_throws KeyError chain[Extra(:section, "world")]
 
             # getindex with symbol
-            @test chain[:a] == fill(1, N_iters)
-            @test chain[:b] == fill(2, N_iters)
-            @test chain[:hello] == fill(3.0, N_iters)
+            @test chain[:a] == fill(1, N_iters, 1)
+            @test chain[:b] == fill(2, N_iters, 1)
+            @test chain[:hello] == fill(3.0, N_iters, 1)
             @test_throws KeyError chain[:c]
             @test_throws KeyError chain[:world]
         end
@@ -90,11 +112,11 @@ using Test
         @testset "ambiguous symbol" begin
             N_iters = 10
             dicts = fill(Dict(Parameter(:a) => 1, Extra(:section, "a") => 3.0), N_iters)
-            chain = FlexiChain{Symbol}(dicts)
+            chain = FlexiChain{Symbol,N_iters,1}(dicts)
 
             # getindex with the full key should be fine
-            @test chain[Parameter(:a)] == fill(1, N_iters)
-            @test chain[Extra(:section, "a")] == fill(3.0, N_iters)
+            @test chain[Parameter(:a)] == fill(1, N_iters, 1)
+            @test chain[Extra(:section, "a")] == fill(3.0, N_iters, 1)
             # but getindex with the symbol should fail
             @test_throws KeyError chain[:a]
             # ... with the correct error message
@@ -108,23 +130,25 @@ using Test
                 Parameter(@varname(b)) => [2.0, 3.0],
                 Parameter(@varname(c)) => (x=4.0, y=5.0),
             )
-            chain = FlexiChain{VarName}(fill(d, N_iters))
-            @test chain[@varname(a)] == fill(1.0, N_iters)
-            @test chain[@varname(b)] == fill([2.0, 3.0], N_iters)
-            @test chain[@varname(c)] == fill((x=4.0, y=5.0), N_iters)
+            chain = FlexiChain{VarName,N_iters,1}(fill(d, N_iters))
+            @test chain[@varname(a)] == fill(1.0, N_iters, 1)
+            @test chain[@varname(b)] == fill([2.0, 3.0], N_iters, 1)
+            @test chain[@varname(c)] == fill((x=4.0, y=5.0), N_iters, 1)
             @test_throws KeyError chain[@varname(d)]
-            @test chain[@varname(b[1])] == fill(2.0, N_iters)
-            @test chain[@varname(b[2])] == fill(3.0, N_iters)
+            @test chain[@varname(b[1])] == fill(2.0, N_iters, 1)
+            @test chain[@varname(b[2])] == fill(3.0, N_iters, 1)
             @test_throws BoundsError chain[@varname(b[3])]
-            @test chain[@varname(c.x)] == fill(4.0, N_iters)
-            @test chain[@varname(c.y)] == fill(5.0, N_iters)
+            @test chain[@varname(c.x)] == fill(4.0, N_iters, 1)
+            @test chain[@varname(c.y)] == fill(5.0, N_iters, 1)
             @test_throws "has no field" chain[@varname(c.z)]
         end
     end
 
     @testset "extract dicts for single iter" begin
         N = 10
-        c = FlexiChain{Symbol}(Dict(Parameter(:a) => rand(N), Extra(:b, "c") => rand(N)))
+        c = FlexiChain{Symbol,N,1}(
+            Dict(Parameter(:a) => rand(N), Extra(:b, "c") => rand(N))
+        )
 
         @testset "get_dict_from_iter" begin
             for i in 1:N
@@ -151,17 +175,19 @@ using Test
             dict1 = Dict(
                 Parameter(:a) => 1, Parameter(:b) => "no", Extra(:hello, "foo") => 3.0
             )
-            chain1 = FlexiChain{Symbol}(fill(dict1, N_iters))
+            chain1 = FlexiChain{Symbol,N_iters,1}(fill(dict1, N_iters))
 
             dict2 = Dict(
                 Parameter(:c) => Foo(),
                 Parameter(:b) => "yes",
                 Extra(:hello, "bar") => "cheese",
             )
-            chain2 = FlexiChain{Symbol}(fill(dict2, N_iters))
+            chain2 = FlexiChain{Symbol,N_iters,1}(fill(dict2, N_iters))
 
             chain3 = merge(chain1, chain2)
-            expected_chain3 = FlexiChain{Symbol}(fill(merge(dict1, dict2), N_iters))
+            expected_chain3 = FlexiChain{Symbol,N_iters,1}(
+                fill(merge(dict1, dict2), N_iters)
+            )
             @test chain3 == expected_chain3
 
             @testset "values are taken from second chain" begin
@@ -172,46 +198,46 @@ using Test
                 # Essentially we want to avoid that the underlying data
                 # is converted into SizedMatrix{N,M,Any} which would
                 # lose type information.
-                @test chain3[Parameter(:a)] isa Vector{Int}
-                @test chain3[Parameter(:b)] isa Vector{String}
-                @test chain3[Extra(:hello, "foo")] isa Vector{Float64}
-                @test chain3[Extra(:hello, "bar")] isa Vector{String}
-                @test chain3[Parameter(:c)] isa Vector{Foo}
+                @test eltype(chain3[Parameter(:a)]) == Int
+                @test eltype(chain3[Parameter(:b)]) == String
+                @test eltype(chain3[Extra(:hello, "foo")]) == Float64
+                @test eltype(chain3[Extra(:hello, "bar")]) == String
+                @test eltype(chain3[Parameter(:c)]) == Foo
             end
         end
 
         @testset "size mismatch" begin
             # Sizes are just incompatible
             dict1 = Dict(Parameter(:a) => 1)
-            chain1 = FlexiChain{Symbol}(fill(dict1, 10))
+            chain1 = FlexiChain{Symbol,10,1}(fill(dict1, 10))
             dict2 = Dict(Parameter(:b) => 2.0)
-            chain2 = FlexiChain{Symbol}(fill(dict2, 100))
+            chain2 = FlexiChain{Symbol,100,1}(fill(dict2, 100))
             @test_throws DimensionMismatch merge(chain1, chain2)
 
             # This is OK (vector combined with N*1 matrix)
             dict3 = Dict(Parameter(:c) => 3.0)
-            chain3 = FlexiChain{Symbol}(fill(dict3, 10, 1))
+            chain3 = FlexiChain{Symbol,10,1}(fill(dict3, 10, 1))
             @test merge(chain1, chain3) isa FlexiChain{Symbol}
 
             # This is not OK
             dict4 = Dict(Parameter(:d) => 3.0)
-            chain4 = FlexiChain{Symbol}(fill(dict4, 5, 2))
+            chain4 = FlexiChain{Symbol,5,2}(fill(dict4, 5, 2))
             @test_throws DimensionMismatch merge(chain1, chain4)
         end
 
         @testset "key type promotion" begin
             dict1 = Dict(Parameter(:a) => 1)
-            chain1 = FlexiChain{Symbol}(fill(dict1, 10))
+            chain1 = FlexiChain{Symbol,10,1}(fill(dict1, 10))
             dict2 = Dict(Parameter("b") => "Hi")
-            chain2 = FlexiChain{String}(fill(dict2, 10))
+            chain2 = FlexiChain{String,10,1}(fill(dict2, 10))
             @test_logs (:warn, r"different key types") merge(chain1, chain2)
             ch = merge(chain1, chain2)
             # Not sure why but `Base.promote_type(Symbol, String)` returns Any
             @test ch isa FlexiChain{Any}
-            @test ch[Parameter(:a)] isa Vector{Int}
-            @test ch[Parameter(:a)] == fill(1, 10)
-            @test ch[Parameter("b")] isa Vector{String}
-            @test ch[Parameter("b")] == fill("Hi", 10)
+            @test ch[Parameter(:a)] isa AbstractMatrix{Int}
+            @test ch[Parameter(:a)] == fill(1, 10, 1)
+            @test ch[Parameter("b")] isa AbstractMatrix{String}
+            @test ch[Parameter("b")] == fill("Hi", 10, 1)
         end
     end
 
@@ -219,7 +245,7 @@ using Test
         @testset "basic application" begin
             N_iters = 10
             d = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain = FlexiChain{Symbol}(fill(d, N_iters))
+            chain = FlexiChain{Symbol,N_iters,1}(fill(d, N_iters))
 
             subsetted1 = FlexiChains.subset(chain, [Parameter(:a)])
             @test typeof(subsetted1) == typeof(chain)
@@ -237,14 +263,14 @@ using Test
         @testset "key not present" begin
             N_iters = 10
             d = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain = FlexiChain{Symbol}(fill(d, N_iters))
+            chain = FlexiChain{Symbol,N_iters,1}(fill(d, N_iters))
             @test_throws KeyError FlexiChains.subset(chain, [Parameter(:x)])
         end
 
         @testset "subset parameters and extras" begin
             N_iters = 10
             d = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain = FlexiChain{Symbol}(fill(d, N_iters))
+            chain = FlexiChain{Symbol,N_iters,1}(fill(d, N_iters))
             @test FlexiChains.subset_parameters(chain) ==
                 FlexiChains.subset(chain, [Parameter(:a)])
             @test FlexiChains.subset_extras(chain) ==
@@ -256,30 +282,31 @@ using Test
         @testset "basic application" begin
             niters1 = 10
             d1 = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain1 = FlexiChain{Symbol}(fill(d1, niters1))
+            chain1 = FlexiChain{Symbol,niters1,1}(fill(d1, niters1))
             niters2 = 20
             d2 = Dict(Parameter(:a) => 2, Extra(:b, "c") => "foo")
-            chain2 = FlexiChain{Symbol}(fill(d2, niters2))
+            chain2 = FlexiChain{Symbol,niters2,1}(fill(d2, niters2))
             chain12 = vcat(chain1, chain2)
             @test chain12 isa FlexiChain{Symbol,niters1 + niters2,1}
             @test size(chain12) == (niters1 + niters2, 1)
-            @test chain12[Parameter(:a)] == vcat(fill(1, niters1), fill(2, niters2))
-            @test chain12[Extra(:b, "c")] == vcat(fill(3.0, niters1), fill("foo", niters2))
+            @test chain12[Parameter(:a)] == vcat(fill(1, niters1, 1), fill(2, niters2, 1))
+            @test chain12[Extra(:b, "c")] ==
+                vcat(fill(3.0, niters1, 1), fill("foo", niters2, 1))
         end
 
         @testset "error on different number of chains" begin
             d1 = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain1 = FlexiChain{Symbol}(fill(d1, 10, 1))
+            chain1 = FlexiChain{Symbol,10,1}(fill(d1, 10, 1))
             d2 = Dict(Parameter(:a) => 2, Extra(:b, "c") => "foo")
-            chain2 = FlexiChain{Symbol}(fill(d2, 10, 2))
+            chain2 = FlexiChain{Symbol,10,2}(fill(d2, 10, 2))
             @test_throws DimensionMismatch vcat(chain1, chain2)
         end
 
         @testset "error on different key type" begin
             d1 = Dict(Parameter(:a) => 1)
-            chain1 = FlexiChain{Symbol}(fill(d1, 10))
+            chain1 = FlexiChain{Symbol,10,1}(fill(d1, 10))
             d2 = Dict(Parameter("a") => 2)
-            chain2 = FlexiChain{String}(fill(d2, 10))
+            chain2 = FlexiChain{String,10,1}(fill(d2, 10))
             @test_throws ArgumentError vcat(chain1, chain2)
         end
     end
@@ -288,9 +315,9 @@ using Test
         @testset "basic application" begin
             N_iters = 10
             d1 = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain1 = FlexiChain{Symbol}(fill(d1, N_iters))
+            chain1 = FlexiChain{Symbol,N_iters,1}(fill(d1, N_iters))
             d2 = Dict(Parameter(:a) => 2, Extra(:b, "c") => "foo")
-            chain2 = FlexiChain{Symbol}(fill(d2, N_iters))
+            chain2 = FlexiChain{Symbol,N_iters,1}(fill(d2, N_iters))
             chain12 = hcat(chain1, chain2)
             @test chain12 isa FlexiChain{Symbol,N_iters,2}
             @test size(chain12) == (N_iters, 2)
@@ -301,11 +328,11 @@ using Test
         @testset "combination of metadata" begin
             N_iters = 10
             d1 = Dict(Parameter(:a) => 1)
-            chain1 = FlexiChain{Symbol}(
+            chain1 = FlexiChain{Symbol,N_iters,1}(
                 fill(d1, N_iters); sampling_time=1, last_sampler_state="foo"
             )
             d2 = Dict(Parameter(:a) => 2)
-            chain2 = FlexiChain{Symbol}(
+            chain2 = FlexiChain{Symbol,N_iters,1}(
                 fill(d2, N_iters); sampling_time=2, last_sampler_state="bar"
             )
             chain12 = hcat(chain1, chain2)
@@ -319,11 +346,11 @@ using Test
         @testset "3 or more inputs" begin
             N_iters = 10
             d1 = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain1 = FlexiChain{Symbol}(fill(d1, N_iters))
+            chain1 = FlexiChain{Symbol,N_iters,1}(fill(d1, N_iters))
             d2 = Dict(Parameter(:a) => 2, Extra(:b, "c") => "foo")
-            chain2 = FlexiChain{Symbol}(fill(d2, N_iters))
+            chain2 = FlexiChain{Symbol,N_iters,1}(fill(d2, N_iters))
             d3 = Dict(Parameter(:x) => 4, Extra(:d, "e") => :y)
-            chain3 = FlexiChain{Symbol}(fill(d3, N_iters))
+            chain3 = FlexiChain{Symbol,N_iters,1}(fill(d3, N_iters))
             chain123 = hcat(chain1, chain2, chain3)
             @test chain123 isa FlexiChain{Symbol,N_iters,3}
             @test size(chain123) == (N_iters, 3)
@@ -335,33 +362,36 @@ using Test
         end
 
         @testset "stacking different numbers of chains" begin
-            chain1 = FlexiChain{Symbol}(fill(Dict(Parameter(:a) => 1), 10))
-            chain2 = FlexiChain{Symbol}(fill(Dict(Parameter(:a) => 3), 10, 2))
+            N_iters = 10
+            chain1 = FlexiChain{Symbol,N_iters,1}(fill(Dict(Parameter(:a) => 1), N_iters))
+            chain2 = FlexiChain{Symbol,N_iters,2}(
+                fill(Dict(Parameter(:a) => 3), N_iters, 2)
+            )
             chain12 = hcat(chain1, chain2)
-            @test chain12 isa FlexiChain{Symbol,10,3}
-            @test size(chain12) == (10, 3)
-            @test chain12[Parameter(:a)] == repeat([1 3 3], 10)
+            @test chain12 isa FlexiChain{Symbol,N_iters,3}
+            @test size(chain12) == (N_iters, 3)
+            @test chain12[Parameter(:a)] == repeat([1 3 3], N_iters)
         end
 
         @testset "error on different number of iters" begin
             d1 = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain1 = FlexiChain{Symbol}(fill(d1, 20))
+            chain1 = FlexiChain{Symbol,20,1}(fill(d1, 20))
             d2 = Dict(Parameter(:a) => 2, Extra(:b, "c") => "foo")
-            chain2 = FlexiChain{Symbol}(fill(d2, 10))
+            chain2 = FlexiChain{Symbol,10,1}(fill(d2, 10))
             @test_throws DimensionMismatch hcat(chain1, chain2)
         end
 
         @testset "error on different key type" begin
             d1 = Dict(Parameter(:a) => 1)
-            chain1 = FlexiChain{Symbol}(fill(d1, 10))
+            chain1 = FlexiChain{Symbol,10,1}(fill(d1, 10))
             d2 = Dict(Parameter("a") => 2)
-            chain2 = FlexiChain{String}(fill(d2, 10))
+            chain2 = FlexiChain{String,10,1}(fill(d2, 10))
             @test_throws ArgumentError hcat(chain1, chain2)
         end
 
         @testset "different parameters in chains" begin
-            chain1 = FlexiChain{Symbol}(fill(Dict(Parameter(:a) => 1), 10))
-            chain2 = FlexiChain{Symbol}(fill(Dict(Parameter(:b) => 2), 10))
+            chain1 = FlexiChain{Symbol,10,1}(fill(Dict(Parameter(:a) => 1), 10))
+            chain2 = FlexiChain{Symbol,10,1}(fill(Dict(Parameter(:b) => 2), 10))
             chain12 = hcat(chain1, chain2)
             @test chain12 isa FlexiChain{Symbol,10,2}
             @test size(chain12) == (10, 2)
@@ -374,11 +404,11 @@ using Test
             # These methods make use of hcat. We just do a basic test
             N_iters = 10
             d1 = Dict(Parameter(:a) => 1, Extra(:b, "c") => 3.0)
-            chain1 = FlexiChain{Symbol}(fill(d1, N_iters))
+            chain1 = FlexiChain{Symbol,N_iters,1}(fill(d1, N_iters))
             d2 = Dict(Parameter(:a) => 2, Extra(:b, "c") => "foo")
-            chain2 = FlexiChain{Symbol}(fill(d2, N_iters))
+            chain2 = FlexiChain{Symbol,N_iters,1}(fill(d2, N_iters))
             d3 = Dict(Parameter(:x) => 4, Extra(:d, "e") => :y)
-            chain3 = FlexiChain{Symbol}(fill(d3, N_iters))
+            chain3 = FlexiChain{Symbol,N_iters,1}(fill(d3, N_iters))
             chain12 = hcat(chain1, chain2)
             @test isequal(AbstractMCMC.chainscat(chain1, chain2), chain12)
             @test isequal(AbstractMCMC.chainsstack([chain1, chain2]), chain12)

--- a/test/sizedmatrix.jl
+++ b/test/sizedmatrix.jl
@@ -1,36 +1,27 @@
 module FCSizedMatrixTests
 
 using FlexiChains: FlexiChains
+using DimensionalData: DimMatrix, Dim
 using Test
 
 @testset verbose = true "sizedmatrix.jl" begin
     @info "Testing sizedmatrix.jl"
 
     @testset "SizedMatrix" begin
-        @testset "m * n" begin
-            x = rand(2, 3)
-            sm = FlexiChains.SizedMatrix{2,3}(x)
-            @test FlexiChains.data(sm) == x
-            @test collect(sm) == x
-            @test eltype(sm) == eltype(x)
-            @test size(sm) == (2, 3)
-            for i in 1:2, j in 1:3
-                @test sm[i, j] == x[i, j]
-            end
-            @test_throws DimensionMismatch FlexiChains.SizedMatrix{2,2}(x)
+        x = rand(2, 3)
+        iter_indices, chain_indices = 1:2:3, 1:3
+        dimx = DimMatrix(x, (Dim{:iter}(iter_indices), Dim{:chain}(chain_indices)))
+        sm = FlexiChains.SizedMatrix{2,3}(x)
+        @test collect(sm) == x
+        @test FlexiChains.data(
+            sm; iter_indices=iter_indices, chain_indices=chain_indices
+        ) == dimx
+        @test eltype(sm) == eltype(x)
+        @test size(sm) == (2, 3)
+        for i in 1:2, j in 1:3
+            @test sm[i, j] == x[i, j]
         end
-
-        @testset "m * 1" begin
-            x = rand(2)
-            sm = FlexiChains.SizedMatrix{2,1}(x)
-            @test FlexiChains.data(sm) == x
-            @test collect(sm) == reshape(x, 2, 1)
-            @test eltype(sm) == eltype(x)
-            @test size(sm) == (2, 1)
-            for i in 1:2
-                @test sm[i, 1] == x[i]
-            end
-        end
+        @test_throws DimensionMismatch FlexiChains.SizedMatrix{2,2}(x)
     end
 end
 

--- a/test/summaries.jl
+++ b/test/summaries.jl
@@ -1,5 +1,7 @@
 module FCSummariesTests
 
+using DimensionalData: DimensionalData as DD
+using DimensionalData.Dimensions: AnonDim
 using FlexiChains:
     FlexiChains,
     FlexiChain,
@@ -62,6 +64,10 @@ ENABLED_SUMMARY_FUNCS = [mean, median, minimum, maximum, std, var]
                         ),
                         ("via user-facing function", func(chain; dims=:iter)),
                     ]
+                        @test collapsed[:a] isa DD.DimMatrix
+                        @test DD.dims(collapsed[:a])[1] isa AnonDim
+                        @test parent(parent(DD.dims(collapsed[:a], :chain))) ==
+                            FlexiChains.chain_indices(chain)
                         @test isapprox(collapsed[:a], func(as; dims=1); nans=true)
                         @test isapprox(
                             collapsed[Parameter(:a)], func(as; dims=1); nans=true
@@ -127,6 +133,10 @@ ENABLED_SUMMARY_FUNCS = [mean, median, minimum, maximum, std, var]
                         ),
                         ("via user-facing function", func(chain; dims=:chain)),
                     ]
+                        @test collapsed[:a] isa DD.DimMatrix
+                        @test parent(parent(DD.dims(collapsed[:a], :iter))) ==
+                            FlexiChains.iter_indices(chain)
+                        @test DD.dims(collapsed[:a])[2] isa AnonDim
                         @test isapprox(collapsed[:a], func(as; dims=2); nans=true)
                         @test isapprox(
                             collapsed[Parameter(:a)], func(as; dims=2); nans=true
@@ -188,6 +198,7 @@ ENABLED_SUMMARY_FUNCS = [mean, median, minimum, maximum, std, var]
                         ),
                         ("via user-facing function", func(chain)),
                     ]
+                        @test collapsed[:a] isa Number
                         @test isapprox(collapsed[:a], func(as); nans=true)
                         @test isapprox(collapsed[Parameter(:a)], func(as); nans=true)
                         @test isapprox(collapsed[:b], func(bs); nans=true)

--- a/test/summaries.jl
+++ b/test/summaries.jl
@@ -55,31 +55,32 @@ ENABLED_SUMMARY_FUNCS = [mean, median, minimum, maximum, std, var]
                     function func_wrapper(x; kwargs...)
                         return func(x; dims=1, kwargs...)
                     end
-                    collapsed = FlexiChains.collapse_iter(chain, func_wrapper)
-                    @test isapprox(collapsed[:a], func(as; dims=1); nans=true)
-                    @test isapprox(collapsed[Parameter(:a)], func(as; dims=1); nans=true)
-                    @test isapprox(collapsed[:b], func(bs; dims=1); nans=true)
-                    @test isapprox(collapsed[Parameter(:b)], func(bs; dims=1); nans=true)
-                    @test isapprox(collapsed[:section, "c"], func(cs; dims=1); nans=true)
-                    @test isapprox(
-                        collapsed[Extra(:section, "c")], func(cs; dims=1); nans=true
-                    )
-                    @test_throws KeyError collapsed[Extra(:section, "d")]
-                    @test_logs (:warn, r"non-numeric") FlexiChains.collapse_iter_chain(
-                        chain, func; warn=true
-                    )
-                    # via user-facing function
-                    collapsed = func(chain; dims=:iter)
-                    @test isapprox(collapsed[:a], func(as; dims=1); nans=true)
-                    @test isapprox(collapsed[Parameter(:a)], func(as; dims=1); nans=true)
-                    @test isapprox(collapsed[:b], func(bs; dims=1); nans=true)
-                    @test isapprox(collapsed[Parameter(:b)], func(bs; dims=1); nans=true)
-                    @test isapprox(collapsed[:section, "c"], func(cs; dims=1); nans=true)
-                    @test isapprox(
-                        collapsed[Extra(:section, "c")], func(cs; dims=1); nans=true
-                    )
-                    @test_throws KeyError collapsed[Extra(:section, "d")]
-                    @test_logs (:warn, r"non-numeric") func(chain; dims=:iter, warn=true)
+                    @testset "$name" for (name, collapsed) in [
+                        (
+                            "via collapse_iter",
+                            FlexiChains.collapse_iter(chain, func_wrapper),
+                        ),
+                        ("via user-facing function", func(chain; dims=:iter)),
+                    ]
+                        @test isapprox(collapsed[:a], func(as; dims=1); nans=true)
+                        @test isapprox(
+                            collapsed[Parameter(:a)], func(as; dims=1); nans=true
+                        )
+                        @test isapprox(collapsed[:b], func(bs; dims=1); nans=true)
+                        @test isapprox(
+                            collapsed[Parameter(:b)], func(bs; dims=1); nans=true
+                        )
+                        @test isapprox(
+                            collapsed[:section, "c"], func(cs; dims=1); nans=true
+                        )
+                        @test isapprox(
+                            collapsed[Extra(:section, "c")], func(cs; dims=1); nans=true
+                        )
+                        @test_throws KeyError collapsed[Extra(:section, "d")]
+                        @test_logs (:warn, r"non-numeric") FlexiChains.collapse_iter_chain(
+                            chain, func; warn=true
+                        )
+                    end
                 end
             end
         end
@@ -119,31 +120,32 @@ ENABLED_SUMMARY_FUNCS = [mean, median, minimum, maximum, std, var]
                     function func_wrapper(x; kwargs...)
                         return func(x; dims=2, kwargs...)
                     end
-                    collapsed = FlexiChains.collapse_chain(chain, func_wrapper)
-                    @test isapprox(collapsed[:a], func(as; dims=2); nans=true)
-                    @test isapprox(collapsed[Parameter(:a)], func(as; dims=2); nans=true)
-                    @test isapprox(collapsed[:b], func(bs; dims=2); nans=true)
-                    @test isapprox(collapsed[Parameter(:b)], func(bs; dims=2); nans=true)
-                    @test isapprox(collapsed[:section, "c"], func(cs; dims=2); nans=true)
-                    @test isapprox(
-                        collapsed[Extra(:section, "c")], func(cs; dims=2); nans=true
-                    )
-                    @test_throws KeyError collapsed[Extra(:section, "d")]
-                    @test_logs (:warn, r"non-numeric") FlexiChains.collapse_iter_chain(
-                        chain, func; warn=true
-                    )
-                    # via user-facing function
-                    collapsed = func(chain; dims=:chain)
-                    @test isapprox(collapsed[:a], func(as; dims=2); nans=true)
-                    @test isapprox(collapsed[Parameter(:a)], func(as; dims=2); nans=true)
-                    @test isapprox(collapsed[:b], func(bs; dims=2); nans=true)
-                    @test isapprox(collapsed[Parameter(:b)], func(bs; dims=2); nans=true)
-                    @test isapprox(collapsed[:section, "c"], func(cs; dims=2); nans=true)
-                    @test isapprox(
-                        collapsed[Extra(:section, "c")], func(cs; dims=2); nans=true
-                    )
-                    @test_throws KeyError collapsed[Extra(:section, "d")]
-                    @test_logs (:warn, r"non-numeric") func(chain; dims=:chain, warn=true)
+                    @testset "$name" for (name, collapsed) in [
+                        (
+                            "via collapse_chain",
+                            FlexiChains.collapse_chain(chain, func_wrapper),
+                        ),
+                        ("via user-facing function", func(chain; dims=:chain)),
+                    ]
+                        @test isapprox(collapsed[:a], func(as; dims=2); nans=true)
+                        @test isapprox(
+                            collapsed[Parameter(:a)], func(as; dims=2); nans=true
+                        )
+                        @test isapprox(collapsed[:b], func(bs; dims=2); nans=true)
+                        @test isapprox(
+                            collapsed[Parameter(:b)], func(bs; dims=2); nans=true
+                        )
+                        @test isapprox(
+                            collapsed[:section, "c"], func(cs; dims=2); nans=true
+                        )
+                        @test isapprox(
+                            collapsed[Extra(:section, "c")], func(cs; dims=2); nans=true
+                        )
+                        @test_throws KeyError collapsed[Extra(:section, "d")]
+                        @test_logs (:warn, r"non-numeric") FlexiChains.collapse_iter_chain(
+                            chain, func; warn=true
+                        )
+                    end
                 end
             end
         end
@@ -179,28 +181,24 @@ ENABLED_SUMMARY_FUNCS = [mean, median, minimum, maximum, std, var]
                     ),
                 )
                 @testset "$func" for func in ENABLED_SUMMARY_FUNCS
-                    # via `collapse_iter_chain`
-                    collapsed = FlexiChains.collapse_iter_chain(chain, func)
-                    @test isapprox(collapsed[:a], func(as); nans=true)
-                    @test isapprox(collapsed[Parameter(:a)], func(as); nans=true)
-                    @test isapprox(collapsed[:b], func(bs); nans=true)
-                    @test isapprox(collapsed[Parameter(:b)], func(bs); nans=true)
-                    @test isapprox(collapsed[:section, "c"], func(cs); nans=true)
-                    @test isapprox(collapsed[Extra(:section, "c")], func(cs); nans=true)
-                    @test_throws KeyError collapsed[Extra(:section, "d")]
-                    @test_logs (:warn, r"non-numeric") FlexiChains.collapse_iter_chain(
-                        chain, func; warn=true
-                    )
-                    # via user-facing function
-                    collapsed = func(chain)
-                    @test isapprox(collapsed[:a], func(as); nans=true)
-                    @test isapprox(collapsed[Parameter(:a)], func(as); nans=true)
-                    @test isapprox(collapsed[:b], func(bs); nans=true)
-                    @test isapprox(collapsed[Parameter(:b)], func(bs); nans=true)
-                    @test isapprox(collapsed[:section, "c"], func(cs); nans=true)
-                    @test isapprox(collapsed[Extra(:section, "c")], func(cs); nans=true)
-                    @test_throws KeyError collapsed[Extra(:section, "d")]
-                    @test_logs (:warn, r"non-numeric") func(chain; warn=true)
+                    @testset "$name" for (name, collapsed) in [
+                        (
+                            "via collapse_iter_chain",
+                            FlexiChains.collapse_iter_chain(chain, func),
+                        ),
+                        ("via user-facing function", func(chain)),
+                    ]
+                        @test isapprox(collapsed[:a], func(as); nans=true)
+                        @test isapprox(collapsed[Parameter(:a)], func(as); nans=true)
+                        @test isapprox(collapsed[:b], func(bs); nans=true)
+                        @test isapprox(collapsed[Parameter(:b)], func(bs); nans=true)
+                        @test isapprox(collapsed[:section, "c"], func(cs); nans=true)
+                        @test isapprox(collapsed[Extra(:section, "c")], func(cs); nans=true)
+                        @test_throws KeyError collapsed[Extra(:section, "d")]
+                        @test_logs (:warn, r"non-numeric") FlexiChains.collapse_iter_chain(
+                            chain, func; warn=true
+                        )
+                    end
                 end
             end
         end


### PR DESCRIPTION
Closes #18 

This is WIP, most things are failing because I have to restructure the entire library.

TODO (Maybe not all in this PR, but ...)

- [x] Fix all the warnings when attempting to `cat` DimArrays
- [x] FlexiChain constructor needs to check the length of indices passed in and error if they are not valid
- [x] Tests for `FlexiChain` calls with `iter_indices` or `chain_indices` keyword arguments
- [x] Add `renumber_iter` and `renumber_chain` functions and tests
- [x] Tests for `iter_indices` and `chain_indices` functions
- [x] Test that getindex returns a DimMatrix with the right dims and indices
- [x] Test that `merge` uses indices + stats from the ~~first~~ second chain
- [x] Test new hcat and vcat behaviour with indices
- [ ] (Will leave this for later) Add a function for subsetting iters/chains of a FlexiChain
- [x] Test that summary stats return AnonDim, and that uncollapsed dimensions' indices are correct
- [x] Use DimArrays for returned, predict and friends
- [x] Go through the README + docs and change vectors -> DimArrays where needed; possibly also add a section on using DimArrays