### PR TITLE
Stack `returned` DimArray values

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+If a model's return value is a `DimArray`, then `returned(model, chain::VNChain)` will now stack the axes together (much like indexing into a FlexiChain).
+
 # 0.2.2
 
 This release contains only documentation updates.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/ext/FlexiChainsDynamicPPLExt.jl
+++ b/ext/FlexiChainsDynamicPPLExt.jl
@@ -212,11 +212,13 @@ end
 
 Returns a `DimMatrix` of the model's return values, re-evaluated using the parameters in
 each iteration of the chain.
+
+If the return value is a `DimArray`, the dimensions will be stacked.
 """
 function DynamicPPL.returned(
     model::DynamicPPL.Model, chain::FlexiChain{<:VarName}
-)::DD.DimMatrix
-    return map(first, reevaluate(model, chain))
+)::DD.DimArray
+    return FlexiChains._raw_to_user_data(chain, map(first, reevaluate(model, chain)))
 end
 
 """

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -517,6 +517,17 @@ function _raw_to_user_data(
     stacked_dimarr = stack(dimmat_of_dimarr)
     return permutedims(stacked_dimarr, (Ndims + 1, Ndims + 2, 1:Ndims...))
 end
+function _raw_to_user_data(
+    ::FlexiChain, dimmat_of_dimarr::DD.DimMatrix{<:DD.DimArray{<:Any,Ndims}}
+) where {Ndims}
+    # assume that the DimMat already has the right iter/chain dims
+    stacked_dimarr = stack(dimmat_of_dimarr)
+    return permutedims(stacked_dimarr, (Ndims + 1, Ndims + 2, 1:Ndims...))
+end
+function _raw_to_user_data(::FlexiChain, dimmat::DD.DimMatrix)
+    # assume that the DimMat already has the right iter/chain dims
+    return dimmat
+end
 
 """
     _replace_data(chain::FlexiChain, new_keytype, new_data)

--- a/test/ext/turing.jl
+++ b/test/ext/turing.jl
@@ -480,6 +480,18 @@ end
             chn = sample(xonly(), NUTS(), 100; chain_type=VNChain, verbose=false)
             @test_throws "not found" returned(xy(), chn)
         end
+
+        @testset "stacks DimArray return values" begin
+            @model function return_dimarray()
+                x ~ Normal()
+                return DD.DimArray(randn(2, 3), (:a, :b))
+            end
+            chn = sample(return_dimarray(), NUTS(), 50; chain_type=VNChain, verbose=false)
+            rets = returned(return_dimarray(), chn)
+            @test rets isa DD.DimArray{T,4} where {T}
+            @test size(rets) == (50, 1, 2, 3)
+            @test DD.name.(DD.dims(rets)) == (:iter, :chain, :a, :b)
+        end
     end
 
     @testset "predict" begin


### PR DESCRIPTION
Closes #91

```julia
julia> using FlexiChains, Turing; import DimensionalData as DD

julia> @model function return_dimarray()
           x ~ Normal()
           return DD.DimArray(randn(2, 3), (:a, :b))
       end
return_dimarray (generic function with 2 methods)

julia> chn = sample(return_dimarray(), NUTS(), 50; chain_type=VNChain, verbose=false)


Sampling 100%|███████████████████████████████████████████████████████| Time: 0:00:00
FlexiChain (50 iterations, 1 chain)
↓ iter=26:75 | → chain=1:1

Parameter type   VarName
Parameters       x
Extra keys       :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :max_hamiltonian_energy_error, :tree_depth, :numerical_error, :step_size, :nom_step_size, :logprior, :loglikelihood, :logjoint


julia> returned(return_dimarray(), chn)
┌ 50×1×2×3 DimArray{Float64, 4} ┐
├───────────────────────────────┴─────────────────────── dims ┐
  ↓ iter Sampled{Int64} 26:75 ForwardOrdered Regular Points,
  → chain Sampled{Int64} 1:1 ForwardOrdered Regular Points,
  ↗ a,
  ⬔ b
└─────────────────────────────────────────────────────────────┘
[:, :, 1, 1]
  ↓ →   1
 26    -0.693712
 27     0.522979
 28     0.929519
 29     0.0947391
 30    -0.435331
 31    -0.930646
 32     0.770802
 33    -1.00756
 34    -0.00721304
 35    -0.451878
 36    -0.449379
  ⋮
 64    -0.86126
 65    -1.25932
 66    -0.459227
 67    -1.70178
 68    -0.307143
 69     1.14078
 70    -1.44101
 71     1.09069
 72     1.50797
 73     0.451405
 74    -0.507889
 75     0.303736
```