### PR TITLE
Implement `MCMCDiagnosticTools.bfmi`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.5.2
+
+Added `MCMCDiagnosticTools.bfmi(::FlexiChain)` to compute the Bayesian fraction of missing information (BFMI) for a chain.
+
 # 0.5.1
 
 Added the `divergences` and `divergences_kwargs` keyword arguments to `pairplot` to additionally superimpose a scatter plot of divergent transitions, as well as a keyword argument `args` that allows passing extra positional arguments to `pairplot`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Finally, functions in Turing.jl which take chains as input work out of the box, 
 returned(model, chain)                 # model's return value for each iteration
 predict(model, chain)                  # posterior predictions
 logjoint(model, chain)                 # log joint probability
-pointwise_logdensities(model, chain)   # log density for each observation
+pointwise_logdensities(model, chain)   # log densities for each tilde-statement
 ```
 
 

--- a/docs/src/summarising.md
+++ b/docs/src/summarising.md
@@ -165,7 +165,8 @@ gelmandiag(chain)
 The available functions are:
 
 ```@docs
-MCMCDiagnosticTools.gelmandiag(::FlexiChains.FlexiChain)
-MCMCDiagnosticTools.gelmandiag_multivariate(::FlexiChains.FlexiChain)
-MCMCDiagnosticTools.discretediag(::FlexiChains.FlexiChain)
+MCMCDiagnosticTools.gelmandiag
+MCMCDiagnosticTools.gelmandiag_multivariate
+MCMCDiagnosticTools.discretediag
+MCMCDiagnosticTools.bfmi
 ```

--- a/src/FlexiChains.jl
+++ b/src/FlexiChains.jl
@@ -69,8 +69,8 @@ using Statistics: mean, median, std, var, quantile
 export mean, median, std, var, quantile
 using StatsBase: summarystats, mad
 export summarystats, mad
-using MCMCDiagnosticTools: ess, rhat, mcse, gelmandiag, gelmandiag_multivariate, discretediag
-export ess, rhat, mcse, gelmandiag, gelmandiag_multivariate, discretediag
+using MCMCDiagnosticTools: ess, rhat, mcse, gelmandiag, gelmandiag_multivariate, discretediag, bfmi
+export ess, rhat, mcse, gelmandiag, gelmandiag_multivariate, discretediag, bfmi
 # For maximum ease of use with Turing...
 const VNChain = FlexiChain{VarName}
 export VarName, @varname, VNChain

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -180,3 +180,20 @@ function MCMCDiagnosticTools.discretediag(
 
     return (; between, within)
 end
+
+"""
+    MCMCDiagnosticTools.bfmi(
+        chain::FlexiChain,
+        energy_key
+    )
+
+Calculate the Bayesian fraction of missing information (BFMI) from the given chain, using
+the specified `energy_key` to identify the key in the chain that corresponds to the
+Hamiltonian energy. Returns a `DimVector` of BFMI values, one per chain (note that even if
+there is only one chain, the result will still be a vector of length 1).
+
+For chains sampled with Turing.jl's HMC/NUTS, the energy key is `:hamiltonian_energy`.
+"""
+function MCMCDiagnosticTools.bfmi(chain::FlexiChain, energy_key)
+    return MCMCDiagnosticTools.bfmi(chain[energy_key])
+end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -9,7 +9,7 @@ using FlexiChains:
     VarName,
     @varname
 using MCMCDiagnosticTools: MCMCDiagnosticTools, gelmandiag, gelmandiag_multivariate,
-    discretediag
+    discretediag, bfmi
 using Test
 
 @testset verbose = true "diagnostics.jl" begin
@@ -213,6 +213,29 @@ using Test
             result = discretediag(chain)
             @test FlexiChains.chain_indices(result.within) ==
                 FlexiChains.chain_indices(chain)
+        end
+    end
+
+    @testset "bfmi" begin
+        N_iters, N_chains = 100, 3
+        energy = randn(N_iters, N_chains)
+        chain = FlexiChain{Symbol}(
+            N_iters, N_chains,
+            Dict(
+                Parameter(:a) => randn(N_iters, N_chains),
+                Extra(:hamiltonian_energy) => energy,
+            ),
+        )
+
+        @testset "matches MCMCDiagnosticTools on raw values" begin
+            result = bfmi(chain, Extra(:hamiltonian_energy))
+            ref = MCMCDiagnosticTools.bfmi(energy)
+            @test result == ref
+        end
+
+        @testset "Symbol shorthand gives same result" begin
+            @test bfmi(chain, :hamiltonian_energy) ==
+                bfmi(chain, Extra(:hamiltonian_energy))
         end
     end
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -8,6 +8,7 @@ using FlexiChains:
     Extra,
     VarName,
     @varname
+import DimensionalData as DD
 using MCMCDiagnosticTools: MCMCDiagnosticTools, gelmandiag, gelmandiag_multivariate,
     discretediag, bfmi
 using Test
@@ -229,8 +230,9 @@ using Test
 
         @testset "matches MCMCDiagnosticTools on raw values" begin
             result = bfmi(chain, Extra(:hamiltonian_energy))
+            @test result isa DD.DimVector
             ref = MCMCDiagnosticTools.bfmi(energy)
-            @test result == ref
+            @test parent(result) == ref
         end
 
         @testset "Symbol shorthand gives same result" begin


### PR DESCRIPTION
Closes #124. This is a stupendously lazy wrapper, but I guess why not.