### PR TITLE
Add stack kwarg for getindex

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,14 @@
+# 0.5.5
+
+Added a new keyword argument `stack` to `getindex` on `FlexiChain`.
+For array-valued parameters, `chain[key, stack=true]` will now return a stacked `DimArray` instead of a `DimArray{AbstractArray}`.
+Conversely, `chain[key, stack=false]` will return a `DimArray{Array}` as before.
+
+The same keyword argument can be used for indexing into `FlexiSummary` as well, with exactly the same implications.
+
+The default value for `stack` is `false`, *except* for the case where the parameter is a `DimArray` of `DimArray`s, in which case the stacking happens by default, but with a deprecation warning.
+In a future version this automatic stacking will be disabled, and to stack `DimArray`s you will have to explicitly set `stack=true`.
+
 # 0.5.4
 
 Added a method, `DimensionalData.DimArray(::FlexiChain, kwargs...)`, to convert a `FlexiChain` into a 3D `DimArray` with dimensions `(iters, chains, parameters)`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/indexing.md
+++ b/docs/src/indexing.md
@@ -138,6 +138,8 @@ If a positional argument is not specified, it defaults to `:`.
 
 ## Keyword arguments: chains
 
+### `iter` and `chain`
+
 In addition to the positional argument, you can also specify the `iter` and `chain` keyword arguments when indexing into the `FlexiChain` object.
 (`FlexiSummary` objects are covered right below this.)
 Both of these are optional, and exist to allow you to select data from specific iterations and/or chains.
@@ -187,6 +189,18 @@ Nonetheless, you can still use all the same selectors as described above, e.g. `
 
 For more information about DimensionalData's selectors, please see [their docs](@extref DimensionalData Selectors).
 
+### `stack`
+
+The `stack` keyword argument only affects parameters which are arrays; other parameters ignore it.
+
+If `stack=false` (the default), then accessing an array-valued parameter will return a `DimArray` of `Array`s.
+If `stack=true`, then the array-valued parameter will be stacked into a single `DimArray`.
+Note that the parameter's axes will be placed at the *end* of the returned DimArray.
+Thus, for example if the parameter `:x` is a `Vector{T}`, then `chn[:x]` will return a `DimArray{T,3}` with shape `(iters, chains, length(x))`.
+
+!!! note "DimArray"
+    In the current version of FlexiChains, for DimArray-valued parameters the stacking happens by default. This will be removed in a future version: you will have to explicitly specify `stack=true` to get this behaviour.
+
 ## Keyword arguments: summaries
 
 !!! note "Positional arguments"
@@ -220,3 +234,7 @@ Thus, for example, if you have a summary that contains the `mean` and `std` of t
 | `1`              | the first statistic, i.e. `:mean`      |
 | `At(:mean)`      | the `:mean` statistic                  |
 | `Not(At(:mean))` | everything but the `:mean` statistic   |
+
+### `stack`
+
+The `stack` keyword argument behaves the same as for `FlexiChain` objects.

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -79,8 +79,6 @@ chn = AbstractMCMC.sample(
 )
 ```
 
-Besides, each entry in `chn[:params]` is stored as a `DimVector`, so when you access the full set of entries you will get a stacked 3-D `DimArray` of `(iters x chains x parameters)` (see below for more information about the stacking).
-
 ## DimensionalDistributions.jl
 
 [Documentation for DimensionalDistributions.jl](https://github.com/sethaxen/DimensionalDistributions.jl)
@@ -88,31 +86,7 @@ Besides, each entry in `chn[:params]` is stored as a `DimVector`, so when you ac
 !!! note
     DimensionalDistributions.jl is not yet registered in the Julia package registry; at present you will need to install it from GitHub using `]add https://github.com/sethaxen/DimensionalDistributions.jl`.
 
-In the quickstart guide we saw that FlexiChains, by default, stores vector-valued parameters together.
-For example, `chn[@varname(x)]` here returns a `DimArray` of `Vector`s:
-
-```@example dimdist
-using FlexiChains, Turing
-
-@model f() = x ~ MvNormal(zeros(3), I)
-chn = sample(f(), MH(), MCMCThreads(), 5, 2; chain_type=VNChain, progress=false)
-
-chn[@varname(x)]
-```
-
-One might like to stack these vectors together, such that `chn[@varname(x)]` returns a three-dimensional `DimArray` instead.
-You can do this manually, for example:
-
-```@example dimdist
-using DimensionalData
-school_dim = Dim{:school}([:a, :b, :c])
-permutedims(stack(map(v -> DimVector(v, school_dim), chn[@varname(x)])), (2, 3, 1))
-```
-
-This is of course a bit tedious.
-Unfortunately, there is not much that FlexiChains can do because `MvNormal()` itself returns plain `Vector`s that do not carry any dimensional information.
-
-But, if you can use the `withdims` wrapper from DimensionalDistributions.jl, you will get a distribution that returns `DimVector`s:
+DimensionalDistributions.jl provides a `withdims` wrapper which lets you create a distribution that returns `DimVector`s:
 
 ```@example dimdist
 using DimensionalDistributions
@@ -120,13 +94,20 @@ dim_mvnormal = withdims(MvNormal(zeros(3), I), school_dim)
 rand(dim_mvnormal)
 ```
 
-And if you use this in a Turing model, then this information will be carried through all the way to FlexiChains, and indexing into this parameter will automatically give you a stacked `DimArray`:
+If you use this in a Turing model, then this information will be carried through all the way to FlexiChains, and indexing into this parameter will let you get a `DimArray` of `DimVector`s.
+This leads to a particularly elegant outcome when accessing this parameter with the `stack=true` keyword argument: FlexiChains will return a 3-dimensional `DimArray` with full dimensional information retained.
 
 ```@example dimdist
-@model f2() = x ~ dim_mvnormal
-chn2 = sample(f2(), MH(), MCMCThreads(), 5, 2; chain_type=VNChain, progress=false)
-chn2[@varname(x)]
+using Turing
+@model f() = x ~ dim_mvnormal
+chn2 = sample(f(), MH(), MCMCThreads(), 5, 2; chain_type=VNChain, progress=false)
+chn2[@varname(x), stack=true]
 ```
+
+!!! note "Default behaviour"
+    For `DimArray`-valued parameters, the `stack=true` keyword argument is not necessary in the current version of FlexiChains as stacking happens by default.
+    However in a future version this will be changed such that the default behaviour even for `DimArray`s is to not stack.
+    Thus it is recommended that you explicitly specify `stack=true` if you want this behaviour.
 
 Sub-VarName indexing also works.
 

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -89,7 +89,11 @@ chn = AbstractMCMC.sample(
 DimensionalDistributions.jl provides a `withdims` wrapper which lets you create a distribution that returns `DimVector`s:
 
 ```@example dimdist
+using Turing # reexports MvNormal and I
+using DimensionalData: Dim
 using DimensionalDistributions
+
+school_dim = Dim{:school}([:a, :b, :c])
 dim_mvnormal = withdims(MvNormal(zeros(3), I), school_dim)
 rand(dim_mvnormal)
 ```
@@ -98,7 +102,7 @@ If you use this in a Turing model, then this information will be carried through
 This leads to a particularly elegant outcome when accessing this parameter with the `stack=true` keyword argument: FlexiChains will return a 3-dimensional `DimArray` with full dimensional information retained.
 
 ```@example dimdist
-using Turing
+using FlexiChains
 @model f() = x ~ dim_mvnormal
 chn2 = sample(f(), MH(), MCMCThreads(), 5, 2; chain_type=VNChain, progress=false)
 chn2[@varname(x), stack=true]

--- a/docs/src/turing.md
+++ b/docs/src/turing.md
@@ -80,7 +80,7 @@ MCMCChains by default will break vector-valued parameters into multiple scalar-v
     If you want to access `theta` as a 3D array of shape `(num_iterations, num_chains, length(theta))`, you can also pass the keyword argument `stack=true` to `getindex`:
 
     ```@example 1
-    chain[@varname(theta); stack=true]
+    chain[@varname(theta), stack=true]
     ```
 
 If you want to obtain only the first element of `theta`, you don't need to manipulate the `DimMatrix`.

--- a/docs/src/turing.md
+++ b/docs/src/turing.md
@@ -77,7 +77,11 @@ chain[@varname(theta)]
 MCMCChains by default will break vector-valued parameters into multiple scalar-valued parameters called `theta[1]`, `theta[2]`, etc., whereas FlexiChains keeps them together as they were defined in the model.
 
 !!! tip "If you want a 3D array..."
-    If you want to access `theta` as a 3D array of shape `(num_iterations, num_chains, vector_length)`, you can manually perform (for example) `stack` and `permutedims`. Alternatively, you can use a distribution that returns `DimVector`s: in this case FlexiChains will automatically convert `theta` as a 3D array for you! Please see [the DimensionalDistributions.jl integration](@ref DimensionalDistributions.jl) for the details.
+    If you want to access `theta` as a 3D array of shape `(num_iterations, num_chains, length(theta))`, you can also pass the keyword argument `stack=true` to `getindex`:
+
+    ```@example 1
+    chain[@varname(theta); stack=true]
+    ```
 
 If you want to obtain only the first element of `theta`, you don't need to manipulate the `DimMatrix`.
 You can just index into the chain with the corresponding `VarName`:

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -534,39 +534,88 @@ function _default_dims(chain::FlexiChain)
     )
 end
 """
-    _raw_to_user_data(chain::FlexiChain, data::Matrix)
+    _stack_arrays(dimarr::DimArray{<:AbstractArray}; name)
+
+Stack a `DimArray` of same-sized `AbstractArray` elements into a single higher-dimensional
+`DimArray`, with the original dimensions placed first and `AnonDim` dimensions for the
+inner array axes. `name` is forwarded to the `DimArray` constructor as the array name.
+"""
+function _stack_arrays(dimarr::DD.DimArray{<:AbstractArray{<:Any, NInner}, NOuter}; name = DD.NoName()) where {NInner, NOuter}
+    # Check that dimensions can be stacked
+    sz = size(first(dimarr))
+    if !all(x -> size(x) == sz, dimarr)
+        throw(
+            DimensionMismatch("cannot stack arrays of different sizes; to return unstacked data, use `stack=false`"),
+        )
+    end
+    # Base.stack always places the outer dimensions (iter/chain in this case) at the end
+    # so we need to permute them back to the front.
+    # at the end.
+    stacked = stack(dimarr)
+    perm = ((NInner + 1):(NInner + NOuter)..., (1:NInner)...)
+    permuted = permutedims(stacked, perm)
+    return if eltype(dimarr) <: DD.DimArray
+        # stack on a DimArray of DimArray will return a DimArray, so we are done here
+        DD.rebuild(permuted; name = name)
+    else
+        # stack on a DimArray of Array will return an Array, so we need to regenerate
+        # the right axes
+        # TODO: This might *lose* information e.g. if the inner arrays have some form of
+        # named axes. We could attempt to preserve this information by dispatching on the
+        # type of the inner array.
+        inner_dims = ntuple(i -> DD.AnonDim(Base.OneTo(sz[i])), NInner)
+        outer_dims = DD.dims(dimarr)
+        all_dims = (outer_dims..., inner_dims...)
+        DD.DimArray(permuted, all_dims; name = name)
+    end
+end
+
+const _STACK_DEPWARN_MSG = (
+    "Implicit stacking of `DimArray` elements will be removed in a" *
+        " future release of FlexiChains. Please either pass `stack=true`" *
+        " to explicitly opt-in, or `stack=false` to disable. The default" *
+        " will change to `false` in a future version."
+)
+
+"""
+    _raw_to_user_data(chain::FlexiChain, data::Matrix; stack=nothing)
 
 Convert `data`, which is a raw matrix of samples, to a `DimensionalData.DimArray` using the
 indices stored in in the `FlexiChain`. This is the format that users expect to obtain when
 indexing into a `FlexiChain`.
 
+The `stack` keyword argument controls stacking of array-valued elements:
+
+- `nothing` (default): auto-stack `DimArray` elements (deprecated; will change to `false`).
+- `true`: stack all `AbstractArray` elements into a higher-dimensional `DimArray` as long as
+  they are all the same size
+- `false`: never stack; return a `DimArray` whose elements are arrays.
+
 !!! important
     This function performs no checks to make sure that the lengths of the indices stored in
 the chain line up with the size of the matrix.
 """
-function _raw_to_user_data(chain::FlexiChain, mat::Matrix; name = DD.NoName())
-    return DD.DimMatrix(mat, _default_dims(chain); name = name)
+function _raw_to_user_data(chain::FlexiChain, mat::Matrix; name = DD.NoName(), stack = nothing)
+    dimmat = DD.DimMatrix(mat, _default_dims(chain); name = name)
+    return _raw_to_user_data(chain, dimmat; name = name, stack = stack)
 end
 function _raw_to_user_data(
-        chain::FlexiChain, mat_of_dimarr::Matrix{<:DD.DimArray{<:Any, Ndims}};
-        name = DD.NoName()
-    ) where {Ndims}
-    dimmat_of_dimarr = DD.DimMatrix(mat_of_dimarr, _default_dims(chain))
-    # This stacked matrix will have the iter and chain dims at the end.
-    stacked_dimarr = stack(dimmat_of_dimarr)
-    return DD.rebuild(permutedims(stacked_dimarr, (Ndims + 1, Ndims + 2, 1:Ndims...)); name = name)
-end
-function _raw_to_user_data(
-        ::FlexiChain, dimmat_of_dimarr::DD.DimMatrix{<:DD.DimArray{<:Any, Ndims}};
-        name = DD.NoName()
-    ) where {Ndims}
-    # assume that the DimMat already has the right iter/chain dims
-    stacked_dimarr = stack(dimmat_of_dimarr)
-    return DD.rebuild(permutedims(stacked_dimarr, (Ndims + 1, Ndims + 2, 1:Ndims...)); name = name)
-end
-function _raw_to_user_data(::FlexiChain, dimmat::DD.DimMatrix; name = DD.NoName())
-    # assume that the DimMat already has the right iter/chain dims
-    return DD.rebuild(dimmat; name = name)
+        ::FlexiChain, dimmat::DD.DimMatrix;
+        name = DD.NoName(), stack = nothing
+    )
+    if !(eltype(dimmat) <: AbstractArray)
+        return DD.rebuild(dimmat; name = name)
+    end
+    if stack === nothing
+        is_dimmat = eltype(dimmat) <: DD.DimArray
+        is_dimmat && @warn _STACK_DEPWARN_MSG
+        stack = is_dimmat
+    end
+    return if stack === false
+        DD.rebuild(dimmat; name = name)
+    else
+        _stack_arrays(dimmat; name = name)
+    end
 end
 
 """

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -73,9 +73,10 @@ The `iter` and `chain` keyword arguments further allow you to extract specific
 iterations or chains from the data corresponding to the given `key`.
 """
 function Base.getindex(
-        fchain::FlexiChain{TKey}, key::ParameterOrExtra{<:TKey}; iter = Colon(), chain = Colon()
+        fchain::FlexiChain{TKey}, key::ParameterOrExtra{<:TKey};
+        iter = Colon(), chain = Colon(), stack = nothing
     ) where {TKey}
-    return _raw_to_user_data(fchain, _get_raw_data(fchain, key); name = string(key))[iter = iter, chain = chain]
+    return _raw_to_user_data(fchain, _get_raw_data(fchain, key); name = string(key), stack = stack)[iter = iter, chain = chain]
 end
 """
     Base.getindex(
@@ -98,9 +99,10 @@ function Base.getindex(
         iter = _UNSPECIFIED_KWARG,
         chain = _UNSPECIFIED_KWARG,
         stat = _UNSPECIFIED_KWARG,
+        stack = nothing,
     ) where {TKey, TIIdx, TCIdx}
     relevant_kwargs = _check_summary_kwargs(fs, iter, chain, stat)
-    user_data = _raw_to_user_data(fs, _get_raw_data(fs, key); name = string(key))
+    user_data = _raw_to_user_data(fs, _get_raw_data(fs, key); name = string(key), stack = stack)
     return _maybe_getindex_with_summary_kwargs(user_data, relevant_kwargs)
 end
 
@@ -170,18 +172,20 @@ If there are multiple matches: for example, if you have a `Parameter(:x)` and al
 it using the actual key.
 """
 function Base.getindex(
-        fchain::FlexiChain{TKey}, sym_key::Symbol; iter = Colon(), chain = Colon()
+        fchain::FlexiChain{TKey}, sym_key::Symbol;
+        iter = Colon(), chain = Colon(), stack = nothing
     ) where {TKey}
     k = _extract_potential_symbol_key(TKey, keys(fchain), sym_key)
-    return fchain[k, iter = iter, chain = chain]
+    return fchain[k, iter = iter, chain = chain, stack = stack]
 end
 # Have to repeat for TKey = Symbol, otherwise the method for getindex(::FlexiChain{T}, ::T)
 # is considered more specific.
 function Base.getindex(
-        fchain::FlexiChain{Symbol}, sym_key::Symbol; iter = Colon(), chain = Colon()
+        fchain::FlexiChain{Symbol}, sym_key::Symbol;
+        iter = Colon(), chain = Colon(), stack = nothing
     )
     k = _extract_potential_symbol_key(Symbol, keys(fchain), sym_key)
-    return fchain[k, iter = iter, chain = chain]
+    return fchain[k, iter = iter, chain = chain, stack = stack]
 end
 """
     Base.getindex(
@@ -204,10 +208,11 @@ function Base.getindex(
         iter = _UNSPECIFIED_KWARG,
         chain = _UNSPECIFIED_KWARG,
         stat = _UNSPECIFIED_KWARG,
+        stack = nothing,
     ) where {TKey}
     k = _extract_potential_symbol_key(TKey, keys(fs), sym_key)
     relevant_kwargs = _check_summary_kwargs(fs, iter, chain, stat)
-    user_data = _raw_to_user_data(fs, _get_raw_data(fs, k); name = string(k))
+    user_data = _raw_to_user_data(fs, _get_raw_data(fs, k); name = string(k), stack = stack)
     return _maybe_getindex_with_summary_kwargs(user_data, relevant_kwargs)
 end
 # Have to repeat for TKey = Symbol, as above
@@ -217,10 +222,11 @@ function Base.getindex(
         iter = _UNSPECIFIED_KWARG,
         chain = _UNSPECIFIED_KWARG,
         stat = _UNSPECIFIED_KWARG,
+        stack = nothing,
     )
     k = _extract_potential_symbol_key(Symbol, keys(fs), sym_key)
     relevant_kwargs = _check_summary_kwargs(fs, iter, chain, stat)
-    user_data = _raw_to_user_data(fs, _get_raw_data(fs, k); name = string(k))
+    user_data = _raw_to_user_data(fs, _get_raw_data(fs, k); name = string(k), stack = stack)
     return _maybe_getindex_with_summary_kwargs(user_data, relevant_kwargs)
 end
 
@@ -237,9 +243,10 @@ end
 Convenience method for retrieving parameters. Equal to `chain[Parameter(parameter_name)]`.
 """
 function Base.getindex(
-        fchain::FlexiChain{TKey}, parameter_name::TKey; iter = Colon(), chain = Colon()
+        fchain::FlexiChain{TKey}, parameter_name::TKey;
+        iter = Colon(), chain = Colon(), stack = nothing
     ) where {TKey}
-    return fchain[Parameter(parameter_name), iter = iter, chain = chain]
+    return fchain[Parameter(parameter_name), iter = iter, chain = chain, stack = stack]
 end
 """
     Base.getindex(
@@ -260,9 +267,10 @@ function Base.getindex(
         iter = _UNSPECIFIED_KWARG,
         chain = _UNSPECIFIED_KWARG,
         stat = _UNSPECIFIED_KWARG,
+        stack = nothing,
     ) where {TKey}
     relevant_kwargs = _check_summary_kwargs(fs, iter, chain, stat)
-    user_data = _raw_to_user_data(fs, _get_raw_data(fs, Parameter(parameter_name)); name = string(Parameter(parameter_name)))
+    user_data = _raw_to_user_data(fs, _get_raw_data(fs, Parameter(parameter_name)); name = string(Parameter(parameter_name)), stack = stack)
     return _maybe_getindex_with_summary_kwargs(user_data, relevant_kwargs)
 end
 

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -1,14 +1,33 @@
 const ChainOrSummary{TKey} = Union{FlexiChain{TKey}, FlexiSummary{TKey}}
 
-const SUMMARY_GETINDEX_KWARGS = """
-!!! note "Keyword arguments"
+const STACK_KWARG_DOC = """
+The `stack` keyword argument lets you control whether array-valued parameters are
+returned as arrays of arrays (`stack=false`, the default) or a single stacked array
+(`stack=true`). Note that when stacking, the dimensions of the inner array will be
+placed at the end of the returned array. For non-array parameters, or when only one
+sample is being accessed, this is ignored.
+"""
 
-    The `iter`, `chain`, and `stat` keyword arguments further allow you to extract specific
-    iterations, chains, or statistics from the data corresponding to the given `key`. Note
-    that these keyword arguments can only be used if the corresponding dimension exists (for
-    example, if the summary statistic has been calculated over all iterations, then the
-    `iter` dimension will not exist and using the `iter` keyword argument will throw an
-    error).
+const CHAIN_GETINDEX_KWARGS = """
+## Keyword arguments
+
+The `iter` and `chain` keyword arguments further allow you to extract specific
+iterations or chains from the data corresponding to the given `key`.
+
+$(STACK_KWARG_DOC)
+"""
+
+const SUMMARY_GETINDEX_KWARGS = """
+## Keyword arguments
+
+The `iter`, `chain`, and `stat` keyword arguments further allow you to extract specific
+iterations, chains, or statistics from the data corresponding to the given `key`. Note
+that these keyword arguments can only be used if the corresponding dimension exists (for
+example, if the summary statistic has been calculated over all iterations, then the
+`iter` dimension will not exist and using the `iter` keyword argument will throw an
+error).
+
+$(STACK_KWARG_DOC)
 """
 
 const _UNSPECIFIED_KWARG = gensym("kwarg")
@@ -61,7 +80,7 @@ end
 """
     Base.getindex(
         fchain::FlexiChain{TKey}, key::ParameterOrExtra{<:TKey};
-        iter=Colon(), chain=Colon()
+        iter=Colon(), chain=Colon(), stack=nothing
     ) where {TKey}
 
 Unambiguously access the data corresponding to the given `key` in the chain.
@@ -69,8 +88,7 @@ Unambiguously access the data corresponding to the given `key` in the chain.
 You will need to use this method if you have multiple keys that convert to the
 same `Symbol`, such as a `Parameter(:x)` and an `Extra(:x)`.
 
-The `iter` and `chain` keyword arguments further allow you to extract specific
-iterations or chains from the data corresponding to the given `key`.
+$(CHAIN_GETINDEX_KWARGS)
 """
 function Base.getindex(
         fchain::FlexiChain{TKey}, key::ParameterOrExtra{<:TKey};
@@ -83,7 +101,8 @@ end
         fs::FlexiSummary{TKey}, key::ParameterOrExtra{<:TKey};
         [iter=Colon(),]
         [chain=Colon(),]
-        [stat=Colon()]
+        [stat=Colon(),]
+        stack=nothing
     ) where {TKey}
 
 Unambiguously access the data corresponding to the given `key` in the summary.
@@ -154,7 +173,7 @@ end
 """
     Base.getindex(
         chain::FlexiChain, sym_key::Symbol;
-        iter=Colon(), chain=Colon()
+        iter=Colon(), chain=Colon(), stack=nothing
     )
 
 The least verbose method to index into a `FlexiChain` is using `Symbol`.
@@ -170,6 +189,8 @@ If there is, then we can return that data. If there are no valid matches, then w
 If there are multiple matches: for example, if you have a `Parameter(:x)` and also an
 `Extra(:x)`, then this method will also throw a `KeyError`. You will then have to index into
 it using the actual key.
+
+$(CHAIN_GETINDEX_KWARGS)
 """
 function Base.getindex(
         fchain::FlexiChain{TKey}, sym_key::Symbol;
@@ -193,7 +214,8 @@ end
         key::Symbol;
         [iter=Colon(),]
         [chain=Colon(),]
-        [stat=Colon()]
+        [stat=Colon(),]
+        stack=nothing
     ) where {TKey}
 
 Index into a summary using an unambiguous `Symbol` key. This requires that the summary has a
@@ -237,10 +259,12 @@ end
 """
     Base.getindex(
         fchain::FlexiChain{TKey}, parameter_name::TKey;
-        iter=Colon(), chain=Colon()
+        iter=Colon(), chain=Colon(), stack=nothing
     ) where {TKey}
 
 Convenience method for retrieving parameters. Equal to `chain[Parameter(parameter_name)]`.
+
+$(CHAIN_GETINDEX_KWARGS)
 """
 function Base.getindex(
         fchain::FlexiChain{TKey}, parameter_name::TKey;
@@ -254,7 +278,8 @@ end
         parameter_name::TKey;
         [iter=Colon(),]
         [chain=Colon(),]
-        [stat=Colon()]
+        [stat=Colon(),]
+        stack=nothing
     ) where {TKey}
 
 Convenience method for retrieving parameters. Equal to `summary[Parameter(parameter_name)]`.

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -318,7 +318,7 @@ function _get_summary_dims(
     return new_dims, dim_indices_to_drop
 end
 """
-    _raw_to_user_data(summary::FlexiSummary, data::AbstractArray)
+    _raw_to_user_data(summary::FlexiSummary, data::AbstractArray; stack=nothing)
 
 Convert `data`, which is a raw 3D array of samples, to either:
 
@@ -326,40 +326,33 @@ Convert `data`, which is a raw 3D array of samples, to either:
   are one or more non-collapsed dimensions; or
 - a single value, if all dimensions are collapsed.
 
+The `stack` keyword argument controls stacking of array-valued elements; see
+[`_raw_to_user_data(::FlexiChain, ...)`](@ref) for details.
+
 !!! important
     This function performs no checks to make sure that the lengths of the indices stored in
 the chain line up with the size of the matrix.
 """
 function _raw_to_user_data(
-        fs::FlexiSummary{TKey, TIIdx, TCIdx, TSIdx}, arr::Array{T, 3};
-        name = DD.NoName()
-    ) where {TKey, TIIdx, TCIdx, TSIdx, T}
+        fs::FlexiSummary{TKey, TIIdx, TCIdx, TSIdx},
+        arr::Array{<:Any, 3};
+        name = DD.NoName(),
+        stack = nothing
+    ) where {TKey, TIIdx, TCIdx, TSIdx}
     new_dims, dim_indices_to_drop = _get_summary_dims(fs)
     dropped_arr = dropdims(arr; dims = dim_indices_to_drop)
-    return if isempty(new_dims)
-        # Scalar value; dropped_arr will be a 0-dimensional array
-        dropped_arr[]
-    else
-        DD.DimArray(dropped_arr, tuple(new_dims...); name = name)
+    # If dropped_arr is a 0-dimensional array, return the scalar itself
+    isempty(new_dims) && return dropped_arr[]
+    # Otherwise we need to check if we need to stack it
+    dimarr = DD.DimArray(dropped_arr, tuple(new_dims...); name = name)
+    if eltype(dropped_arr) <: DD.DimArray && stack === nothing
+        @warn _STACK_DEPWARN_MSG
+        stack = true
     end
-end
-function _raw_to_user_data(
-        fs::FlexiSummary{TKey, TIIdx, TCIdx, TSIdx}, arr::Array{<:DD.DimArray{<:Any, Ndims}, 3};
-        name = DD.NoName()
-    ) where {TKey, TIIdx, TCIdx, TSIdx, Ndims}
-    new_dims, dim_indices_to_drop = _get_summary_dims(fs)
-    dropped_arr = dropdims(arr; dims = dim_indices_to_drop)
-    return if isempty(new_dims)
-        dropped_arr[]
+    return if stack === true && eltype(dropped_arr) <: AbstractArray
+        _stack_arrays(dimarr; name = name)
     else
-        n_new_dims = length(new_dims) # between 1 and 3, iter/chain/stat
-        arr_of_arr = DD.DimArray(dropped_arr, tuple(new_dims...))
-        stacked_arr = stack(arr_of_arr)
-        # iter/chain/stat will be the final dimensions. We want them to be the first
-        return DD.rebuild(
-            permutedims(stacked_arr, ((Ndims + 1):(Ndims + n_new_dims)..., (1:Ndims)...));
-            name = name
-        )
+        dimarr
     end
 end
 

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -116,10 +116,11 @@ in the chain, then that will be returned. If not, then `@varname(x)` will be che
 and if that is a vector-valued parameter then all of its first entries will be returned.
 """
 function Base.getindex(
-        fchain::FlexiChain{<:VarName}, vn::VarName; iter = Colon(), chain = Colon()
+        fchain::FlexiChain{<:VarName}, vn::VarName;
+        iter = Colon(), chain = Colon(), stack = nothing
     )
     raw = _get_raw_data(fchain, Parameter(vn))
-    return _raw_to_user_data(fchain, raw; name = string(Parameter(vn)))[iter = iter, chain = chain]
+    return _raw_to_user_data(fchain, raw; name = string(Parameter(vn)), stack = stack)[iter = iter, chain = chain]
 end
 """
     Base.getindex(
@@ -141,9 +142,10 @@ function Base.getindex(
         iter = _UNSPECIFIED_KWARG,
         chain = _UNSPECIFIED_KWARG,
         stat = _UNSPECIFIED_KWARG,
+        stack = nothing,
     )
     relevant_kwargs = _check_summary_kwargs(fs, iter, chain, stat)
-    user_data = _raw_to_user_data(fs, _get_raw_data(fs, Parameter(vn)); name = string(Parameter(vn)))
+    user_data = _raw_to_user_data(fs, _get_raw_data(fs, Parameter(vn)); name = string(Parameter(vn)), stack = stack)
     return _maybe_getindex_with_summary_kwargs(user_data, relevant_kwargs)
 end
 
@@ -201,7 +203,8 @@ Get a parameter from the chain that matches the target VarName but with an arbit
 See [`Prefixed`](@ref) for details.
 """
 function Base.getindex(
-        fchain::FlexiChain{<:VarName}, prefixed::Prefixed; iter = Colon(), chain = Colon()
+        fchain::FlexiChain{<:VarName}, prefixed::Prefixed;
+        iter = Colon(), chain = Colon(), stack = nothing
     )
     vn, optic = prefixed_get_key_and_optic(Set(FlexiChains.parameters(fchain)), prefixed)
     # We could use get_raw_data here, but we don't need to since we already calculated the
@@ -209,7 +212,7 @@ function Base.getindex(
     combined_vn = AbstractPPL.append_optic(vn, optic)
     raw = fchain._data[Parameter(vn)]
     raw_with_optic = _map_optic(optic, raw, prefixed)
-    return _raw_to_user_data(fchain, raw_with_optic; name = string(Parameter(combined_vn)))[iter = iter, chain = chain]
+    return _raw_to_user_data(fchain, raw_with_optic; name = string(Parameter(combined_vn)), stack = stack)[iter = iter, chain = chain]
 end
 """
     Base.getindex(
@@ -229,11 +232,12 @@ function Base.getindex(
         iter = _UNSPECIFIED_KWARG,
         chain = _UNSPECIFIED_KWARG,
         stat = _UNSPECIFIED_KWARG,
+        stack = nothing,
     )
     relevant_kwargs = _check_summary_kwargs(fs, iter, chain, stat)
     vn, optic = prefixed_get_key_and_optic(Set(FlexiChains.parameters(fs)), prefixed)
     raw = fs._data[Parameter(vn)]
     combined_vn = AbstractPPL.append_optic(vn, optic)
-    user_data = _raw_to_user_data(fs, _map_optic(optic, raw, prefixed); name = string(Parameter(combined_vn)))
+    user_data = _raw_to_user_data(fs, _map_optic(optic, raw, prefixed); name = string(Parameter(combined_vn)), stack = stack)
     return _maybe_getindex_with_summary_kwargs(user_data, relevant_kwargs)
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -358,21 +358,109 @@ using Random: Xoshiro
             end
         end
 
-        @testset "DimArray element type" begin
-            dimarr = rand(DD.X([:a, :b, :c]), DD.Y(100.0:50:200.0))
-            Niters, Nchains = 100, 3
-            d = Dict(Parameter(:a) => fill(dimarr, Niters, Nchains))
+        @testset "stack keyword" begin
+            arr = [1.0, 2.0, 3.0]
+            dimarr = DD.DimArray([10.0, 20.0, 30.0], DD.X([:a, :b, :c]))
+            Niters, Nchains = 10, 3
+            d = Dict(
+                Parameter(:arr) => fill(arr, Niters, Nchains),
+                Parameter(:dimarr) => fill(dimarr, Niters, Nchains),
+                Parameter(:scalar) => rand(Niters, Nchains),
+            )
             chain = FlexiChain{Symbol}(Niters, Nchains, d)
-            returned_as = chain[:a]
-            @test returned_as isa DD.DimArray{Float64, 4}
-            @test size(returned_as) == (Niters, Nchains, 3, 3)
-            @test DD.dims(returned_as) isa Tuple{DD.Dim{:iter}, DD.Dim{:chain}, DD.X, DD.Y}
-            @test parent(DD.val(DD.dims(returned_as), :iter)) ==
-                FlexiChains.iter_indices(chain)
-            @test parent(DD.val(DD.dims(returned_as), :chain)) ==
-                FlexiChains.chain_indices(chain)
-            @test parent(DD.val(DD.dims(returned_as), :X)) == [:a, :b, :c]
-            @test parent(DD.val(DD.dims(returned_as), :Y)) == collect(100.0:50:200.0)
+
+            @testset "scalar parameter is unaffected by stack" begin
+                s_default = chain[:scalar]
+                s_true = chain[:scalar, stack = true]
+                s_false = chain[:scalar, stack = false]
+                @test s_default isa DD.DimMatrix{Float64}
+                @test s_true isa DD.DimMatrix{Float64}
+                @test s_false isa DD.DimMatrix{Float64}
+                @test s_default == s_true == s_false
+            end
+
+            @testset "Array parameter" begin
+                @testset "stack=false" begin
+                    result = chain[:arr, stack = false]
+                    @test result isa DD.DimMatrix{Vector{Float64}}
+                    @test size(result) == (Niters, Nchains)
+                    @test result[1, 1] == arr
+                end
+                @testset "stack=true" begin
+                    result = chain[:arr, stack = true]
+                    @test result isa DD.DimArray{Float64, 3}
+                    @test size(result) == (Niters, Nchains, 3)
+                    @test DD.dims(result) isa
+                        Tuple{DD.Dim{:iter}, DD.Dim{:chain}, DD.AnonDim}
+                    @test result[1, 1, :] == arr
+                end
+                @testset "default (no stack kwarg)" begin
+                    result = chain[:arr]
+                    @test result isa DD.DimMatrix{Vector{Float64}}
+                    @test size(result) == (Niters, Nchains)
+                    @test result[1, 1] == arr
+                end
+            end
+
+            @testset "DimArray parameter" begin
+                @testset "stack=false" begin
+                    result = chain[:dimarr, stack = false]
+                    @test result isa DD.DimMatrix{<:DD.DimArray}
+                    @test size(result) == (Niters, Nchains)
+                    @test result[1, 1] == dimarr
+                end
+                @testset "stack=true" begin
+                    result = chain[:dimarr, stack = true]
+                    @test result isa DD.DimArray{Float64, 3}
+                    @test size(result) == (Niters, Nchains, 3)
+                    @test DD.dims(result) isa
+                        Tuple{DD.Dim{:iter}, DD.Dim{:chain}, DD.X}
+                    @test DD.lookup(DD.dims(result, DD.X)) ==
+                        DD.lookup(DD.dims(dimarr, DD.X))
+                    @test result[1, 1, :] == parent(dimarr)
+                end
+                @testset "default (no stack kwarg) emits deprecation warning" begin
+                    result = @test_logs(
+                        (:warn, FlexiChains._STACK_DEPWARN_MSG),
+                        chain[:dimarr],
+                    )
+                    @test result isa DD.DimArray{Float64, 3}
+                    @test size(result) == (Niters, Nchains, 3)
+                end
+            end
+
+            @testset "stack=true with mismatched sizes errors" begin
+                arr1 = [1.0, 2.0]
+                arr2 = [1.0, 2.0, 3.0]
+                mat = hcat(fill([arr1, arr2], 3)...)
+                d_bad = Dict(Parameter(:x) => mat)
+                bad_chain = FlexiChain{Symbol}(2, 3, d_bad)
+                @test_throws DimensionMismatch bad_chain[:x, stack = true]
+                result = bad_chain[:x, stack = false]
+                @test result isa DD.DimMatrix
+                @test result[1, 1] == arr1
+                @test result[2, 1] == arr2
+            end
+
+            @testset "stack with iter/chain subsetting" begin
+                result = chain[:arr, stack = true, iter = 1:3, chain = DD.At(1)]
+                @test result isa DD.DimArray{Float64, 2}
+                @test size(result) == (3, 3)
+                @test result[1, :] == arr
+
+                result = chain[:dimarr, stack = true, iter = 1:3, chain = DD.At(1)]
+                @test result isa DD.DimArray{Float64, 2}
+                @test size(result) == (3, 3)
+                @test result[1, :] == parent(dimarr)
+            end
+
+            @testset "stack with both dims collapsed" begin
+                result = chain[:arr, stack = true, iter = DD.At(1), chain = DD.At(1)]
+                @test result == arr
+
+                result = chain[:dimarr, stack = true, iter = DD.At(1), chain = DD.At(1)]
+                @test result == dimarr
+            end
         end
     end
 

--- a/test/summaries.jl
+++ b/test/summaries.jl
@@ -402,47 +402,131 @@ const WORKS_ON_STRING = [minimum, maximum, prod]
             @test fs[@varname(x[1])] isa DD.DimVector
         end
 
-        @testset "DimArray element type" begin
-            dimarr = rand(DD.X([:a, :b, :c]), DD.Y(100.0:50:200.0))
-            Niters, Nchains = 100, 3
-            d = Dict(Parameter(:a) => fill(dimarr, Niters, Nchains))
+        @testset "stack keyword" begin
+            arr = [1.0, 2.0, 3.0]
+            dimarr = DD.DimArray([10.0, 20.0, 30.0], DD.X([:a, :b, :c]))
+            Niters, Nchains = 10, 3
+            d = Dict(
+                Parameter(:arr) => fill(arr, Niters, Nchains),
+                Parameter(:dimarr) => fill(dimarr, Niters, Nchains),
+                Parameter(:scalar) => rand(Niters, Nchains),
+            )
             chain = FlexiChain{Symbol}(Niters, Nchains, d)
 
-            @testset "dims=:both" begin
+            @testset "dims=:both (all collapsed)" begin
                 m = mean(chain; split_varnames = false)
-                mean_a = m[:a]
-                @test mean_a isa DD.DimMatrix{Float64}
-                @test size(mean_a) == (3, 3)
-                @test DD.dims(mean_a) == DD.dims(dimarr)
+
+                @testset "scalar" begin
+                    @test m[:scalar] isa Float64
+                    @test m[:scalar, stack = true] isa Float64
+                    @test m[:scalar, stack = false] isa Float64
+                end
+
+                @testset "Array parameter" begin
+                    @test m[:arr, stack = false] == arr
+                    @test m[:arr, stack = true] == arr
+                    @test m[:arr] == arr
+                end
+
+                @testset "DimArray parameter" begin
+                    @test m[:dimarr, stack = false] == dimarr
+                    @test m[:dimarr, stack = true] == dimarr
+                    # no warning because there is no stacking going on
+                    @test m[:dimarr] == dimarr
+                end
             end
 
             @testset "dims=:iter" begin
                 m = mean(chain; dims = :iter, split_varnames = false)
-                mean_a = m[:a]
-                @test mean_a isa DD.DimArray{Float64, 3}
-                @test size(mean_a) == (Nchains, 3, 3)
-                @test parent(DD.val(DD.dims(mean_a), :chain)) ==
-                    FlexiChains.chain_indices(m)
-                @test DD.dims(mean_a)[2:3] == DD.dims(dimarr)[:]
-            end
 
-            @testset "dims=:chain" begin
-                m = mean(chain; dims = :chain, split_varnames = false)
-                mean_a = m[:a]
-                @test mean_a isa DD.DimArray{Float64, 3}
-                @test size(mean_a) == (Niters, 3, 3)
-                @test parent(DD.val(DD.dims(mean_a), :iter)) == FlexiChains.iter_indices(m)
-                @test DD.dims(mean_a)[2:3] == DD.dims(dimarr)[:]
+                @testset "scalar" begin
+                    s_default = m[:scalar]
+                    s_true = m[:scalar, stack = true]
+                    s_false = m[:scalar, stack = false]
+                    @test s_default isa DD.DimVector{Float64}
+                    @test s_true isa DD.DimVector{Float64}
+                    @test s_false isa DD.DimVector{Float64}
+                    @test s_default == s_true == s_false
+                end
+
+                @testset "Array parameter" begin
+                    result = m[:arr, stack = false]
+                    @test result isa DD.DimVector{Vector{Float64}}
+                    @test size(result) == (Nchains,)
+                    @test result[1] == arr
+
+                    result = m[:arr, stack = true]
+                    @test result isa DD.DimArray{Float64, 2}
+                    @test size(result) == (Nchains, 3)
+                    @test DD.dims(result) isa Tuple{DD.Dim{:chain}, DD.AnonDim}
+                    @test result[1, :] == arr
+
+                    result = m[:arr]
+                    @test result isa DD.DimVector{Vector{Float64}}
+                end
+
+                @testset "DimArray parameter" begin
+                    result = m[:dimarr, stack = false]
+                    @test result isa DD.DimVector{<:DD.DimArray}
+                    @test size(result) == (Nchains,)
+                    @test result[1] == dimarr
+
+                    result = m[:dimarr, stack = true]
+                    @test result isa DD.DimArray{Float64, 2}
+                    @test size(result) == (Nchains, 3)
+                    @test DD.dims(result) isa Tuple{DD.Dim{:chain}, DD.X}
+                    @test result[1, :] == parent(dimarr)
+
+                    result = @test_logs(
+                        (:warn, FlexiChains._STACK_DEPWARN_MSG),
+                        m[:dimarr],
+                    )
+                    @test result isa DD.DimArray{Float64, 2}
+                    @test size(result) == (Nchains, 3)
+                end
             end
 
             @testset "with multiple statistics" begin
-                ms = FlexiChains.collapse(chain, [mean, std]; dims = :iter, split_varnames = false)
-                summary_a = ms[:a, stat = DD.At(:mean)]
-                @test summary_a isa DD.DimArray{Float64, 3}
-                @test size(summary_a) == (Nchains, 3, 3)
-                @test parent(DD.val(DD.dims(summary_a), :chain)) ==
-                    FlexiChains.chain_indices(ms)
-                @test DD.dims(summary_a)[2:3] == DD.dims(dimarr)[:]
+                ms = FlexiChains.collapse(
+                    chain, [mean, std]; dims = :iter, split_varnames = false
+                )
+
+                @testset "Array parameter" begin
+                    result = ms[:arr, stack = true, stat = DD.At(:mean)]
+                    @test result isa DD.DimArray{Float64, 2}
+                    @test size(result) == (Nchains, 3)
+                    @test DD.dims(result) isa Tuple{DD.Dim{:chain}, DD.AnonDim}
+                    @test result[1, :] == arr
+
+                    result = ms[:arr, stack = true]
+                    @test result isa DD.DimArray{Float64, 3}
+                    @test size(result) == (Nchains, 2, 3)
+                    @test DD.dims(result) isa
+                        Tuple{DD.Dim{:chain}, DD.Dim{:stat}, DD.AnonDim}
+
+                    result = ms[:arr, stack = false, stat = DD.At(:mean)]
+                    @test result isa DD.DimVector{Vector{Float64}}
+                end
+
+                @testset "DimArray parameter" begin
+                    result = ms[:dimarr, stack = true, stat = DD.At(:mean)]
+                    @test result isa DD.DimArray{Float64, 2}
+                    @test size(result) == (Nchains, 3)
+                    @test DD.dims(result) isa Tuple{DD.Dim{:chain}, DD.X}
+
+                    result = ms[:dimarr, stack = true]
+                    @test result isa DD.DimArray{Float64, 3}
+                    @test size(result) == (Nchains, 2, 3)
+                    @test DD.dims(result) isa
+                        Tuple{DD.Dim{:chain}, DD.Dim{:stat}, DD.X}
+
+                    result = @test_logs(
+                        (:warn, FlexiChains._STACK_DEPWARN_MSG),
+                        ms[:dimarr, stat = DD.At(:mean)],
+                    )
+                    @test result isa DD.DimArray{Float64, 2}
+                    @test size(result) == (Nchains, 3)
+                end
             end
         end
     end


### PR DESCRIPTION
Closes #118 

The default behaviour is to *not* stack. The rationale for this is:

1. I want to avoid breaking behaviour in this release
2. The array-of-array is more faithful to the actual data
3. Stacking can throw an error if the internal arrays do not all have the same size, which is a poor user experience if they didn't explicitly ask for it. If stacking was the default, to avoid that situation we would have to distinguish between the two cases of "user didn't specify, so we'll attempt to stack and gracefully fall back", vs "user specified stack, so we'll error loudly", which is a faff.

Point (1) leads to an awkward case where arrays of DimArrays currently *do* get stacked by default, because of #78. That behaviour is preserved in this version, but will be unified in a future version to not stack.

Demo:

```julia
julia> using Turing, FlexiChains

julia> @model f() = x ~ MvNormal(zeros(2), I)
f (generic function with 2 methods)

julia> chn = sample(f(), NUTS(), 10; chain_type=VNChain)
┌ Info: Found initial step size
└   ϵ = 3.2
Sampling 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:00
FlexiChain (10 iterations, 1 chain)
↓ iter=6:15 | → chain=1:1

Parameter type   VarName
Parameters       x
Extra keys       :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :max_hamiltonian_energy_error, :tree_depth, :numerical_error, :step_size, :nom_step_size, :logprior, :loglikelihood, :logjoint


julia> chn[@varname(x)]
┌ 10×1 DimArray{Vector{Float64}, 2} Parameter(x) ┐
├────────────────────────────────────────────────┴───── dims ┐
  ↓ iter Sampled{Int64} 6:15 ForwardOrdered Regular Points,
  → chain Sampled{Int64} 1:1 ForwardOrdered Regular Points
└────────────────────────────────────────────────────────────┘
  ↓ →  1
  6     [-1.498, -0.75455]
  7     [0.435126, -0.280032]
  8     [-1.06832, -0.459719]
  9     [0.864982, 0.343087]
 10     [1.10073, -0.996125]
 11     [-0.312481, -0.407086]
 12     [-0.446148, 0.424503]
 13     [-0.0275162, -0.392622]
 14     [1.3139, -0.235053]
 15     [0.359908, 0.832947]

julia> chn[@varname(x), stack=true]
┌ 10×1×2 DimArray{Float64, 3} Parameter(x) ┐
├──────────────────────────────────────────┴──────────── dims ┐
  ↓ iter Sampled{Int64} 6:15 ForwardOrdered Regular Points,
  → chain Sampled{Int64} 1:1 ForwardOrdered Regular Points,
  ↗ AnonDim Sampled{Int64} 1:2 ForwardOrdered Regular Points
└─────────────────────────────────────────────────────────────┘
[:, :, 1]
  ↓ →   1
  6    -1.498
  7     0.435126
  8    -1.06832
  9     0.864982
 10     1.10073
 11    -0.312481
 12    -0.446148
 13    -0.0275162
 14     1.3139
 15     0.359908
```