### PR TITLE
Implement Tables.jl interface for summaries

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+# 0.6.8
+
+Implemented a Tables.jl interface for `Wide(::FlexiSummary)`.
+Unlike `Wide(::FlexiChain)`, where each parameter is given a different column, for a `FlexiSummary` each _statistic_ is given a different column, and the parameters are split up into rows.
+
+`FlexiSummary` itself also has a default Tables.jl interface which simply delegates to `Wide`.
+
 # 0.6.7
 
 Add an InferenceObjects.jl extension, which allows conversion of a `FlexiChain` into an `InferenceObjects.InferenceData` via `InferenceObjects.convert_to_inference_data(chain::FlexiChain)`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -345,9 +345,9 @@ For example if you use AdvancedHMC.jl then you can pass the `chain_type=FlexiCha
 
 [Documentation for Tables.jl](https://tables.juliadata.org/stable/)
 
-FlexiChains implements a Tables.jl interface which allows you to easily convert a `FlexiChain` into any type that consumes tabular data, e.g., a `DataFrame`.
+FlexiChains implements a Tables.jl interface which allows you to easily convert a `FlexiChain` or `FlexiSummary` into any type that consumes tabular data, e.g., a `DataFrame`.
 
-In fact, FlexiChains implements *two* different Tables.jl interfaces: one for wide data and one for long data.
+In fact, FlexiChains implements *two* different Tables.jl interfaces for chains: one for wide data and one for long data.
 
 This is best demonstrated with an example.
 First let's sample a chain as usual:
@@ -382,3 +382,33 @@ Both the [`Wide`](@ref) and [`Long`](@ref) wrapper structs accept keyword argume
 Wide
 Long
 ```
+
+For `FlexiSummary`, the long format is not (yet?) supported: only the wide format is implemented.
+In contrast to `Wide(::FlexiChain)`, where each _parameter_ is given a different column, the wide format for `FlexiSummary` splits each _statistic_ into a separate column.
+
+```@example tables
+fs = summarystats(chn)
+DataFrame(Wide(fs))
+```
+
+Like for `FlexiChain`, the `Wide` wrapper is the default Tables.jl implementation for `FlexiSummary`, so you can also just do `DataFrame(fs)`.
+
+`Wide(::FlexiSummary)` takes the same keyword arguments as `Wide(::FlexiChain)`.
+
+!!! note "Splitting VarNames"
+
+    Please note that the act of summarising will typically already cause array-valued variables to be split up.
+    If this has already been done, then using `Wide(...; split_varnames=false)` cannot reverse this!
+
+    ```@example tables
+    w = Wide(mean(fs), split_varnames=false)
+    DataFrame(w)
+    ```
+
+    Notice how `z[1]` and `z[2]` are already split up despite the `split_varnames=false` argument.
+    If you want to prevent this, you need to specify `split_varnames=false` at the summary step as well:
+
+    ```@example tables
+    w = Wide(mean(fs; split_varnames=false), split_varnames=false)
+    DataFrame(w)
+    ```

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -401,7 +401,7 @@ Like for `FlexiChain`, the `Wide` wrapper is the default Tables.jl implementatio
     If this has already been done, then using `Wide(...; split_varnames=false)` cannot reverse this!
 
     ```@example tables
-    w = Wide(mean(fs), split_varnames=false)
+    w = Wide(mean(chn), split_varnames=false)
     DataFrame(w)
     ```
 
@@ -409,6 +409,6 @@ Like for `FlexiChain`, the `Wide` wrapper is the default Tables.jl implementatio
     If you want to prevent this, you need to specify `split_varnames=false` at the summary step as well:
 
     ```@example tables
-    w = Wide(mean(fs; split_varnames=false), split_varnames=false)
+    w = Wide(mean(chn; split_varnames=false), split_varnames=false)
     DataFrame(w)
     ```

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -284,16 +284,14 @@ function Base.Array(
     return parent(da)
 end
 
-## Tables.jl interface
-
-function _prepare_chain(chn::FlexiChain; split_varnames::Bool = true, parameters_only::Bool = true)
+function _prepare_chain_or_summary(cs::ChainOrSummary; split_varnames::Bool = true, parameters_only::Bool = true)
     if parameters_only
-        chn = FlexiChains.subset_parameters(chn)
+        cs = FlexiChains.subset_parameters(cs)
     end
     if split_varnames
-        chn = FlexiChains._split_varnames(chn)
+        cs = FlexiChains._split_varnames(cs)
     end
-    return chn
+    return cs
 end
 
 function _check_duplicate_keys(ks)
@@ -376,19 +374,19 @@ faster than `chain`.
 
 $(WIDE_LONG_KWARGS_DOC)
 """
-struct Wide{F <: FlexiChain, N <: NamedTuple}
-    chn::F
-    # A precomputed mapping from Symbol(k) => k for all keys in `chn`.
+struct Wide{F <: ChainOrSummary, N <: NamedTuple}
+    cs::F
+    # A precomputed mapping from Symbol(k) => k for all keys in `cs`.
     symbol_to_keys::N
 
-    function Wide(chn::FlexiChain; split_varnames::Bool = true, parameters_only::Bool = true)
-        chn = _prepare_chain(chn; split_varnames, parameters_only)
+    function Wide(cs::ChainOrSummary; split_varnames::Bool = true, parameters_only::Bool = true)
+        cs = _prepare_chain_or_summary(cs; split_varnames, parameters_only)
         # Strip parameter/extra wrappers and convert to Symbol for column names.
-        ks = Tuple(FlexiChains.get_name.(keys(chn)))
+        ks = Tuple(FlexiChains.get_name.(keys(cs)))
         sym_ks = Symbol.(ks)
         _check_duplicate_keys(sym_ks)
         symbol_to_keys = NamedTuple{sym_ks}(ks)
-        return new{typeof(chn), typeof(symbol_to_keys)}(chn, symbol_to_keys)
+        return new{typeof(cs), typeof(symbol_to_keys)}(cs, symbol_to_keys)
     end
 end
 
@@ -457,7 +455,7 @@ struct Long{F <: FlexiChain, K <: Tuple}
     original_keys::K
 
     function Long(chn::FlexiChain; split_varnames::Bool = true, parameters_only::Bool = true)
-        chn = _prepare_chain(chn; split_varnames, parameters_only)
+        chn = _prepare_chain_or_summary(chn; split_varnames, parameters_only)
         original_keys = if parameters_only
             Tuple(FlexiChains.get_name.(keys(chn)))
         else
@@ -473,22 +471,91 @@ Tables.istable(::Type{<:Long}) = true
 Tables.columnaccess(::Type{<:Wide}) = true
 Tables.columnaccess(::Type{<:Long}) = true
 
-# Default Tables.jl implementation for FlexiChain itself
+# Default Tables.jl implementation for FlexiChain and FlexiSummary itself
 Tables.columns(chn::FlexiChain) = Wide(chn; split_varnames = true, parameters_only = true)
+Tables.columns(fs::FlexiSummary) = Wide(fs; split_varnames = true, parameters_only = true)
 
-# Wide
-Tables.columnnames(s::Wide) = [FlexiChains.ITER_DIM_NAME, FlexiChains.CHAIN_DIM_NAME, keys(s.symbol_to_keys)...]
-function Tables.getcolumn(s::Wide, col::Symbol)
+# Wide chain
+Tables.columnnames(s::Wide{<:FlexiChain}) = [FlexiChains.ITER_DIM_NAME, FlexiChains.CHAIN_DIM_NAME, keys(s.symbol_to_keys)...]
+function Tables.getcolumn(s::Wide{<:FlexiChain}, col::Symbol)
     return if col === FlexiChains.ITER_DIM_NAME
-        repeat(iter_indices(s.chn); outer = FlexiChains.nchains(s.chn))
+        repeat(iter_indices(s.cs); outer = FlexiChains.nchains(s.cs))
     elseif col === FlexiChains.CHAIN_DIM_NAME
-        repeat(chain_indices(s.chn); inner = FlexiChains.niters(s.chn))
+        repeat(chain_indices(s.cs); inner = FlexiChains.niters(s.cs))
     else
-        vec(s.chn[s.symbol_to_keys[col]])
+        vec(s.cs[s.symbol_to_keys[col]])
     end
 end
 Tables.getcolumn(s::Wide, col::Int) = Tables.getcolumn(s, Tables.columnnames(s)[col])
 Tables.columns(s::Wide) = s
+
+# Wide summary
+function Tables.columnnames(w::Wide{<:FlexiSummary})
+    cols = [FlexiChains.PARAM_DIM_NAME]
+    if iter_indices(w.cs) !== nothing
+        push!(cols, FlexiChains.ITER_DIM_NAME)
+    end
+    if chain_indices(w.cs) !== nothing
+        push!(cols, FlexiChains.CHAIN_DIM_NAME)
+    end
+    si = stat_indices(w.cs)
+    if si !== nothing
+        append!(cols, parent(si))
+    else
+        push!(cols, FlexiChains.STAT_DIM_NAME)
+    end
+    return cols
+end
+function Tables.getcolumn(w::Wide{<:FlexiSummary}, col::Symbol)
+    ii = iter_indices(w.cs)
+    ci = chain_indices(w.cs)
+    si = stat_indices(w.cs)
+    nic = if ii === nothing && ci === nothing
+        1
+    elseif ii === nothing
+        length(ci)
+    elseif ci === nothing
+        length(ii)
+    else
+        throw(ArgumentError("summary has both iter and chain dimensions; should not happen"))
+    end
+    nparams = length(w.symbol_to_keys)
+    return if col === FlexiChains.PARAM_DIM_NAME
+        ks = collect(values(w.symbol_to_keys))
+        repeat(ks; inner = nic)
+    elseif col === FlexiChains.ITER_DIM_NAME
+        ii === nothing && throw(ArgumentError("summary does not have an iter dimension; should not happen"))
+        repeat(ii; outer = nparams)
+    elseif col === FlexiChains.CHAIN_DIM_NAME
+        ci === nothing && throw(ArgumentError("summary does not have a chain dimension; should not happen"))
+        repeat(ci; outer = nparams)
+    elseif col === FlexiChains.STAT_DIM_NAME
+        if si === nothing
+            if ii === nothing && ci === nothing
+                [w.cs[k] for k in values(w.symbol_to_keys)]
+            else
+                vcat([parent(w.cs[k]) for k in values(w.symbol_to_keys)]...)
+            end
+        else
+            throw(ArgumentError("summary has a non-collapse stat dimension but :stat column was requested; should not happen"))
+        end
+    else
+        # named stat dimension.
+        if si === nothing
+            throw(ArgumentError("summary does not have a stat dimension; should not happen"))
+        else
+            if col in parent(si)
+                if ii === nothing && ci === nothing
+                    [w.cs[k, stat = At(col)] for k in values(w.symbol_to_keys)]
+                else
+                    vcat([parent(w.cs[k, stat = At(col)]) for k in values(w.symbol_to_keys)]...)
+                end
+            else
+                throw(ArgumentError("summary does not have a stat named $col; should not happen"))
+            end
+        end
+    end
+end
 
 # Long
 const VALUE_COL_NAME = :value

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -327,15 +327,17 @@ const WIDE_LONG_KWARGS_DOC = """
 
 """
     FlexiChains.Wide(
-        chn::FlexiChain;
+        chn::Union{<:FlexiChain,<:FlexiSummary};
         split_varnames::Bool=true,
         parameters_only::Bool=true
     )
 
-A wrapper struct indicating that a `FlexiChain` should be converted to a 'wide' table
-format, where each parameter is a separate column.
+A wrapper struct indicating a 'wide' table format. The exact meaning depends on whether the
+input is a `FlexiChain` or a `FlexiSummary`. A `FlexiChain` will have each parameter in a
+separate column; conversely, a `FlexiSummary` will have each summary statistic in a separate
+column.
 
-## Example
+## Example (`FlexiChain`)
 
 ```julia
 using Turing, FlexiChains, DataFrames
@@ -373,6 +375,27 @@ faster than `chain`.
 ```
 
 $(WIDE_LONG_KWARGS_DOC)
+
+## Example (`FlexiSummary`)
+
+```julia
+julia> df = DataFrame(Wide(summarystats(chn)))
+2×10 DataFrame
+ Row │ param     mean       std       mcse      ess_bulk  ess_tail  rh ⋯
+     │ VarName…  Float64    Float64   Float64   Float64   Float64   Fl ⋯
+─────┼──────────────────────────────────────────────────────────────────
+   1 │ x         -0.253812  0.987327  0.193554   26.0206    25.641     ⋯
+   2 │ b          0.5       0.512989  0.113426   20.4545   NaN      Na
+                                                       4 columns omitted
+
+julia> df = DataFrame(Wide(mean(chn)))
+2×2 DataFrame
+ Row │ param     stat
+     │ VarName…  Float64
+─────┼─────────────────────
+   1 │ x         -0.253812
+   2 │ b          0.5
+```
 """
 struct Wide{F <: ChainOrSummary, N <: NamedTuple}
     cs::F

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -12,12 +12,14 @@ using FlexiChains:
     @varname,
     iter_indices,
     chain_indices,
-    stat_indices
+    stat_indices,
+    summarystats
 using DataFrames: DataFrame, names, nrow, ncol
 using DimensionalData: DimensionalData as DD, val, At
 using OrderedCollections: OrderedDict
 using Statistics: mean, std
 using Test
+using FlexiChains: Tables
 
 @testset verbose = true "flatten.jl" begin
     @info "Testing flatten.jl"
@@ -375,6 +377,124 @@ using Test
             # Long preserves original keys, so Parameter("s") and Extra(:s) are distinct
             df = DataFrame(Long(dup_chain; parameters_only = false))
             @test nrow(df) == 5 * 1 * 2
+        end
+
+        @testset "Wide summary" begin
+            N_iters, N_chains = 10, 2
+            as = rand(N_iters, N_chains)
+            bs = rand(N_iters, N_chains)
+            d_summary = OrderedDict(
+                Parameter(:a) => as,
+                Parameter(:b) => bs,
+                Extra(:lp) => -rand(N_iters, N_chains),
+            )
+            sc = FlexiChain{Symbol}(N_iters, N_chains, d_summary)
+
+            @testset "mean(chain) — all dims collapsed, single stat" begin
+                fs = mean(sc)
+                df = DataFrame(Wide(fs))
+                @test nrow(df) == 2
+                @test names(df) == ["param", "stat"]
+                @test df.param == [:a, :b]
+                for row in eachrow(df)
+                    @test row.stat ≈ fs[row.param]
+                end
+            end
+
+            @testset "mean(chain; dims=:iter) — chain dim retained, single stat" begin
+                fs = mean(sc; dims = :iter)
+                df = DataFrame(Wide(fs))
+                @test nrow(df) == 2 * N_chains
+                @test names(df) == ["param", "chain", "stat"]
+                @test df.param == repeat([:a, :b]; inner = N_chains)
+                @test df.chain == repeat(1:N_chains; outer = 2)
+                for row in eachrow(df)
+                    @test row.stat ≈ fs[row.param, chain = At(row.chain)]
+                end
+            end
+
+            @testset "mean(chain; dims=:chain) — iter dim retained, single stat" begin
+                fs = mean(sc; dims = :chain)
+                df = DataFrame(Wide(fs))
+                @test nrow(df) == 2 * N_iters
+                @test names(df) == ["param", "iter", "stat"]
+                @test df.param == repeat([:a, :b]; inner = N_iters)
+                @test df.iter == repeat(1:N_iters; outer = 2)
+                for row in eachrow(df)
+                    @test row.stat ≈ fs[row.param, iter = At(row.iter)]
+                end
+            end
+
+            @testset "collapse(chain, [mean, std]; dims=:both) — named stat cols" begin
+                fs = FlexiChains.collapse(sc, [mean, std]; dims = :both)
+                df = DataFrame(Wide(fs))
+                @test nrow(df) == 2
+                @test names(df) == ["param", "mean", "std"]
+                @test df.param == [:a, :b]
+                for row in eachrow(df)
+                    for stat_name in [:mean, :std]
+                        @test row[stat_name] ≈ fs[row.param, stat = At(stat_name)]
+                    end
+                end
+            end
+
+            @testset "collapse(chain, [mean, std]; dims=:iter) — chain + named stats" begin
+                fs = FlexiChains.collapse(sc, [mean, std]; dims = :iter)
+                df = DataFrame(Wide(fs))
+                @test nrow(df) == 2 * N_chains
+                @test names(df) == ["param", "chain", "mean", "std"]
+                @test df.param == repeat([:a, :b]; inner = N_chains)
+                @test df.chain == repeat(1:N_chains; outer = 2)
+                for row in eachrow(df)
+                    for stat_name in [:mean, :std]
+                        @test row[stat_name] ≈ fs[row.param, stat = At(stat_name), chain = At(row.chain)]
+                    end
+                end
+            end
+
+            @testset "FlexiSummary directly as table source" begin
+                fs = FlexiChains.collapse(sc, [mean, std]; dims = :both)
+                df = DataFrame(fs)
+                df_wide = DataFrame(Wide(fs))
+                @test names(df) == names(df_wide)
+                @test nrow(df) == nrow(df_wide)
+                for col in names(df)
+                    @test df[!, col] == df_wide[!, col]
+                end
+            end
+
+            @testset "parameters_only=false includes extras" begin
+                fs = mean(sc)
+                df = DataFrame(Wide(fs; parameters_only = false))
+                @test nrow(df) == 3
+                @test :lp in df.param
+            end
+
+            @testset "VarName-keyed summary with array-valued param" begin
+                d_vn = OrderedDict(
+                    Parameter(@varname(a)) => 1.0,
+                    Parameter(@varname(b)) => [2.0, 3.0],
+                )
+                vn_chain = FlexiChain{VarName}(N_iters, N_chains, fill(d_vn, N_iters, N_chains))
+                fs = mean(vn_chain; split_varnames = false)
+
+                @testset "split_varnames=true" begin
+                    df = DataFrame(Wide(fs; split_varnames = true))
+                    @test nrow(df) == 3
+                    @test names(df) == ["param", "stat"]
+                    for row in eachrow(df)
+                        @test row.stat ≈ fs[row.param]
+                    end
+                end
+                @testset "split_varnames=false" begin
+                    df = DataFrame(Wide(fs; split_varnames = false))
+                    @test nrow(df) == 2
+                    @test names(df) == ["param", "stat"]
+                    for row in eachrow(df)
+                        @test row.stat ≈ fs[row.param]
+                    end
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
Closes #215 

Still needs:

- [x] tests
- [x] improved docstring for `Wide`

## Setup

```julia
using DynamicPPL, FlexiChains, Distributions, LinearAlgebra, DataFrames

@model function scrap()
    x ~ Normal(0, 1)
    y ~ Normal(x, 1)
    z ~ MvNormal(zeros(2), I)
end

chn = FlexiChains._make_prior_chain(scrap(), 100, 2)

#=
╭─FlexiChain (100 iterations, 2 chains) ───────────────────────────────────────────────────────╮
│ ↓ iter  = 1:100                                                                              │
│ → chain = 1:2                                                                                │
│                                                                                              │
│ Parameters (3) ── VarName                                                                    │
│  Float64          x, y                                                                       │
│  Vector{Float64}  z                                                                          │
│                                                                                              │
│ Extras (3)                                                                                   │
│  Float64  logprior, loglikelihood, logjoint                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────╯
=#
```

## Examples

```julia
julia> DataFrame(summarystats(chn))
4×10 DataFrame
 Row │ param    mean         std       mcse       ess_bulk  ess_tail  rhat      q5        q50  ⋯
     │ VarName  Float64      Float64   Float64    Float64   Float64   Float64   Float64   Floa ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────
   1 │ x        -0.0653651   0.947005  0.0632301   223.592   182.726  1.0019    -1.64819  -0.1 ⋯
   2 │ y        -0.0231841   1.37725   0.0949735   210.293   212.621  0.997952  -2.31417  -0.0
   3 │ z[1]     -0.00645489  0.952631  0.0651638   207.026   181.817  0.998219  -1.52358  -0.0
   4 │ z[2]     -0.0983199   1.01565   0.0805007   161.0     119.428  0.995728  -1.74125  -0.0
                                                                               2 columns omitted

julia> DataFrame(mean(chn))
4×2 DataFrame
 Row │ param    stat
     │ VarName  Float64
─────┼──────────────────────
   1 │ x        -0.0653651
   2 │ y        -0.0231841
   3 │ z[1]     -0.00645489
   4 │ z[2]     -0.0983199

julia> DataFrame(mean(chn; dims=:iter))
8×3 DataFrame
 Row │ param    chain  stat
     │ VarName  Int64  Float64
─────┼────────────────────────────
   1 │ x            1  -0.0619022
   2 │ x            2  -0.0688281
   3 │ y            1   0.0638681
   4 │ y            2  -0.110236
   5 │ z[1]         1   0.047084
   6 │ z[1]         2  -0.0599938
   7 │ z[2]         1  -0.13077
   8 │ z[2]         2  -0.0658693

julia> DataFrame(FlexiChains.collapse(chn, [mean, std]; dims=:iter))
8×4 DataFrame
 Row │ param    chain  mean        std
     │ VarName  Int64  Float64     Float64
─────┼──────────────────────────────────────
   1 │ x            1  -0.0619022  0.981304
   2 │ x            2  -0.0688281  0.91636
   3 │ y            1   0.0638681  1.32205
   4 │ y            2  -0.110236   1.43166
   5 │ z[1]         1   0.047084   0.942494
   6 │ z[1]         2  -0.0599938  0.964414
   7 │ z[2]         1  -0.13077    0.978081
   8 │ z[2]         2  -0.0658693  1.0558
```
