### PR TITLE
Merge summaries

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,8 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           preview_url="https://pysm.dev/FlexiChains.jl/previews/PR${PR_NUMBER}/"
-          body="<!-- docs-preview-tag --> [Docs preview for PR #${PR_NUMBER}](${preview_url})"
+          body="<!-- docs-preview-tag -->
+          [Docs preview for PR #${PR_NUMBER}](${preview_url})"
           existing=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | contains("docs-preview-tag")) | .id' | head -1)
           if [ -z "$existing" ]; then
             gh pr comment "$PR_NUMBER" --body "$body"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,14 @@
+# 0.6.12
+
+Added `Base.merge(fs1::FlexiSummary, fs2::FlexiSummary)` to merge two summaries together.
+
+The resulting `FlexiSummary` will have keys that are the union of the keys of `fs1` and `fs2`, as well as statistics that are the union of the statistics of `fs1` and `fs2`.
+
+In general, the value for a given key and statistic in the merged summary will be taken from `fs2` if it exists, and from `fs1` otherwise.
+For key/statistic combinations that don't exist in either summary, the value will be `missing`.
+
+For the most part, it is expected that the two summaries being merged will have either the same keys (in which case this amounts to concatenation of statistics), or the same statistics (i.e., concatenation of keys).
+
 # 0.6.11
 
 Added the `split_interval` keyword argument to `PosteriorStats.hdi(::FlexiChain)` and `PosteriorStats.eti(::FlexiChain)`, which allows you to specify that the returned interval should be split into its lower and upper bounds as separate statistics.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/summarising.md
+++ b/docs/src/summarising.md
@@ -70,23 +70,6 @@ The key `v` is still present in the result (since `mean` and `std` could be comp
 However, notice that other statistics such as `ess` are no longer defined, and so return `missing` values.
 Just like before, the string `s` is dropped since no statistics could be computed for it.
 
-## Conversion to Arrays
-
-Before we go on to the next step, it's worth noting that `FlexiSummary` objects can be converted to `DimArray`s (more informative) or plain `Array`s.
-This is useful for e.g. extracting the mean of all variables as an array:
-
-```@example stats
-st = summarystats(chain)
-DimArray(st)
-```
-
-In the next section we'll describe individual statistics.
-Here is a sneak peek: `mean(chain)` will return a `FlexiSummary` object, and you can convert it to a `DimArray` if you want to extract the mean values as an array:
-
-```@example stats
-DimArray(mean(chain))
-```
-
 ## Individual statistics
 
 Sometimes you may only want to calculate a single statistic.
@@ -98,10 +81,17 @@ All of these functions return a `FlexiSummary` where the `:stat` dimension has a
 That means that if you want to access the mean of a variable `@varname(a)` you don't need to further use the `stat` dimension:
 
 ```@example stats
-m = mean(chain)
+mn = mean(chain)
 # Not needed: mean_f = m[@varname(f), stat=At(:mean)]
 # Just do:
-mean_f = m[@varname(f)]
+mean_f = mn[@varname(f)]
+```
+
+In fact, behind the scenes, the actual name of the statistic is retained.
+This means that, for example, if you convert the result to a `DataFrame`, the column will be named `mean` rather than `stat`:
+
+```@example stats
+DataFrame(mn)
 ```
 
 ```@docs
@@ -168,6 +158,26 @@ There are two things worth mentioning, which we will note in passing here withou
 
 2. The name of the statistic is inferred from the function. Sometimes this doesn't work out nicely, for example if you pass an anonymous function. In this case you can provide a tuple of `(:name, function)` instead of just the function.
 
+## Merging summaries
+
+As an alternative to using `collapse`, you can also calculate separate summaries and then merge them.
+
+```@example stats
+mn = mean(chain)
+sd = std(chain)
+
+merge(mn, sd)
+```
+
+```@docs
+Base.merge(::FlexiChains.FlexiSummary, ::FlexiChains.FlexiSummary)
+```
+
+## Density intervals
+
+It is worth just noting briefly here that FlexiChains has a PosteriorStats extension which allows you to calculate highest density intervals and equal-tailed intervals.
+Please see the [PosteriorStats integration section](@ref integrations-posteriorstats) for details.
+
 ## MCMC diagnostics
 
 There are a number of functions in MCMCDiagnosticTools.jl which do not nicely fit the notion of 'collapse over one or more dimensions'.
@@ -187,4 +197,20 @@ MCMCDiagnosticTools.gelmandiag
 MCMCDiagnosticTools.gelmandiag_multivariate
 MCMCDiagnosticTools.discretediag
 MCMCDiagnosticTools.bfmi
+```
+
+## Flattening summaries
+
+Finally, `FlexiSummary` objects can be converted to `DimArray`s or `DataFrame`s, just like `FlexiChain`s.
+This is useful for various analyses and visualisations.
+
+```@example stats
+st = summarystats(chain)
+DimArray(st)
+```
+
+```@example stats
+using DataFrames
+
+DataFrame(st)
 ```

--- a/ext/FlexiChainsPosteriorStatsExt.jl
+++ b/ext/FlexiChainsPosteriorStatsExt.jl
@@ -23,11 +23,10 @@ function _split_interval(fs::FlexiChains.FlexiSummary{TKey}, lower_name::Symbol,
         combined = cat(lower, upper; dims = 3) # new 3D array with stat dimension of size 2
         new_data[k] = combined
     end
-    ii = FlexiChains.iter_indices(fs)
-    ci = FlexiChains.chain_indices(fs)
     si = FlexiChains._make_categorical([lower_name, upper_name])
-    fs = FlexiChains.FlexiSummary{TKey}(new_data, ii, ci, si)
-    return fs
+    return FlexiChains.FlexiSummary{TKey}(
+        new_data, fs._iter_indices, fs._chain_indices, si, false,
+    )
 end
 
 """

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -9,7 +9,7 @@ function _gelmandiag_summary(
         data[Parameter(k)] = reshape([psrf[i], psrfci[i]], 1, 1, 2)
     end
     return FlexiSummary{TKey}(
-        data, nothing, nothing, _make_categorical([:psrf, :psrfci])
+        data, nothing, nothing, _make_categorical([:psrf, :psrfci]), false
     )
 end
 
@@ -121,7 +121,7 @@ function MCMCDiagnosticTools.discretediag(
             1, 1, 3,
         )
     end
-    between = FlexiSummary{TKey}(between_data, nothing, nothing, stat_names)
+    between = FlexiSummary{TKey}(between_data, nothing, nothing, stat_names, false)
 
     # Within-chain summary: iter dimension collapsed, chain dimension kept
     num_chains = length(FlexiChains.chain_indices(chain))
@@ -134,7 +134,7 @@ function MCMCDiagnosticTools.discretediag(
         within_data[Parameter(k)] = vals
     end
     within = FlexiSummary{TKey}(
-        within_data, nothing, FlexiChains.chain_indices(chain), stat_names,
+        within_data, nothing, FlexiChains.chain_indices(chain), stat_names, false,
     )
 
     return (; between, within)

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -525,13 +525,19 @@ function Base.getindex(
     new_chain_indices, new_chain_lookup = _get_indices_and_lookup(
         fs, chain_indices, get(relevant_kwargs, :chain, Colon())
     )
-    new_stat_indices, new_stat_lookup = _get_indices_and_lookup(
-        fs, stat_indices, get(relevant_kwargs, :stat, Colon())
-    )
+    new_stat_indices, new_stat_lookup = if fs._drop_stat_dim
+        Colon(), fs._stat_indices
+    else
+        _get_indices_and_lookup(
+            fs, stat_indices, get(relevant_kwargs, :stat, Colon())
+        )
+    end
     keys_to_include = _get_multi_keys(TKey, keys(fs), keyvec)
     new_data = OrderedDict{ParameterOrExtra{<:TKey}, AbstractArray{<:Any, 3}}(
         k => _get_raw_data(fs, k)[new_iter_indices, new_chain_indices, new_stat_indices] for
             k in keys_to_include
     )
-    return FlexiSummary{TKey}(new_data, new_iter_lookup, new_chain_lookup, new_stat_lookup)
+    return FlexiSummary{TKey}(
+        new_data, new_iter_lookup, new_chain_lookup, new_stat_lookup, fs._drop_stat_dim,
+    )
 end

--- a/src/interface/equal.jl
+++ b/src/interface/equal.jl
@@ -40,7 +40,8 @@ function Base.:(==)(c1::FlexiSummary{TKey1}, c2::FlexiSummary{TKey2}) where {TKe
         (c1._data == c2._data) &
         (c1._iter_indices == c2._iter_indices) &
         (c1._chain_indices == c2._chain_indices) &
-        (c1._stat_indices == c2._stat_indices)
+        (c1._stat_indices == c2._stat_indices) &
+        (c1._drop_stat_dim == c2._drop_stat_dim)
 end
 
 """
@@ -68,7 +69,8 @@ function Base.isequal(
         isequal(c1._data, c2._data) &&
         isequal(c1._iter_indices, c2._iter_indices) &&
         isequal(c1._chain_indices, c2._chain_indices) &&
-        isequal(c1._stat_indices, c2._stat_indices)
+        isequal(c1._stat_indices, c2._stat_indices) &&
+        c1._drop_stat_dim == c2._drop_stat_dim
 end
 
 """

--- a/src/interface/mergesubset.jl
+++ b/src/interface/mergesubset.jl
@@ -68,6 +68,97 @@ function Base.merge(c1::FlexiChain{TKey1}, c2::FlexiChain{TKey2}) where {TKey1, 
 end
 
 """
+    Base.merge(
+        s1::FlexiSummary{TKey1},
+        s2::FlexiSummary{TKey2},
+    ) where {TKey1,TKey2}
+
+Merge two `FlexiSummary`s along both the key and statistic dimensions.
+
+The two summaries must have the same iteration and chain indices, and both must have known
+stat names (i.e. `_stat_indices !== nothing`).
+
+The merged result contains the union of keys and the union of stat names from both summaries.
+For each `(key, stat)` pair, the value from `s2` takes priority over `s1`. Pairs that exist
+in neither summary are filled with `missing`.
+
+If the key types are different, the resulting `FlexiSummary` will have a promoted key type,
+and a warning will be issued.
+"""
+function Base.merge(
+        s1::FlexiSummary{TKey1}, s2::FlexiSummary{TKey2}
+    ) where {TKey1, TKey2}
+    # Validate iter and chain indices match
+    s1._iter_indices == s2._iter_indices || throw(
+        DimensionMismatch(
+            "cannot merge FlexiSummaries with different iteration indices."
+        ),
+    )
+    s1._chain_indices == s2._chain_indices || throw(
+        DimensionMismatch(
+            "cannot merge FlexiSummaries with different chain indices."
+        ),
+    )
+    # Both must have known stat names
+    si1 = s1._stat_indices
+    si2 = s2._stat_indices
+    si1 === nothing && throw(
+        ArgumentError("cannot merge: first FlexiSummary has unknown stat names")
+    )
+    si2 === nothing && throw(
+        ArgumentError("cannot merge: second FlexiSummary has unknown stat names")
+    )
+    names1 = parent(si1)
+    names2 = parent(si2)
+    # Promote key type if necessary
+    TKeyNew = if TKey1 != TKey2
+        new = Base.promote_type(TKey1, TKey2)
+        @warn "Merging FlexiSummaries with different key types: $(TKey1) and $(TKey2). The resulting summary will have $(new) as the key type."
+        new
+    else
+        TKey1
+    end
+    # Merged stat names and keys: s1's order first, then new from s2
+    merged_names = union(names1, names2)
+    all_keys = union(collect(keys(s1._data)), collect(keys(s2._data)))
+    # Build index maps: stat name -> position in original arrays
+    s1_stat_idx = Dict(name => i for (i, name) in enumerate(names1))
+    s2_stat_idx = Dict(name => i for (i, name) in enumerate(names2))
+    # Determine sizes for padding with missing
+    iter_size = s1._iter_indices === nothing ? 1 : length(s1._iter_indices)
+    chain_size = s1._chain_indices === nothing ? 1 : length(s1._chain_indices)
+    # Merge data: for each (key, stat), s2 wins if it has the pair
+    new_data = OrderedDict{ParameterOrExtra{<:TKeyNew}, Array{<:Any, 3}}()
+    for k in all_keys
+        arr = Array{Any, 3}(undef, iter_size, chain_size, length(merged_names))
+        fill!(arr, missing)
+        # Fill from s1
+        if haskey(s1._data, k)
+            for (name, i) in s1_stat_idx
+                j = findfirst(==(name), merged_names)
+                arr[:, :, j] .= @view s1._data[k][:, :, i]
+            end
+        end
+        # Overwrite from s2 (s2 wins)
+        if haskey(s2._data, k)
+            for (name, i) in s2_stat_idx
+                j = findfirst(==(name), merged_names)
+                arr[:, :, j] .= @view s2._data[k][:, :, i]
+            end
+        end
+        new_data[k] = map(identity, arr)
+    end
+    new_si = _make_categorical(merged_names)
+    return FlexiSummary{TKeyNew}(
+        new_data, s1._iter_indices, s1._chain_indices, new_si, false,
+    )
+end
+
+function Base.merge(s1::FlexiSummary, s2::FlexiSummary, rest::FlexiSummary...)
+    return foldl(merge, rest; init = merge(s1, s2))
+end
+
+"""
     subset_parameters(cs::ChainOrSummary)
 
 Subset a chain or summary, retaining only the `Parameter` keys.

--- a/src/interface/mergesubset.jl
+++ b/src/interface/mergesubset.jl
@@ -75,8 +75,7 @@ end
 
 Merge two `FlexiSummary`s along both the key and statistic dimensions.
 
-The two summaries must have the same iteration and chain indices, and both must have known
-stat names (i.e. `_stat_indices !== nothing`).
+The two summaries must have the same iteration and chain indices.
 
 The merged result contains the union of keys and the union of stat names from both summaries.
 For each `(key, stat)` pair, the value from `s2` takes priority over `s1`. Pairs that exist
@@ -88,7 +87,10 @@ and a warning will be issued.
 function Base.merge(
         s1::FlexiSummary{TKey1}, s2::FlexiSummary{TKey2}
     ) where {TKey1, TKey2}
-    # Validate iter and chain indices match
+    # Validate iter and chain indices match. This is stricter than merge on FlexiChain, but
+    # for summaries, I'm genuinely unsure of how one can ever have a situation where one
+    # would want to merge summaries with different iteration or chain indices. (To the
+    # reader: please feel free to open issues / PRs if you have a use case!)
     s1._iter_indices == s2._iter_indices || throw(
         DimensionMismatch(
             "cannot merge FlexiSummaries with different iteration indices."
@@ -99,18 +101,11 @@ function Base.merge(
             "cannot merge FlexiSummaries with different chain indices."
         ),
     )
-    # Both must have known stat names
-    si1 = s1._stat_indices
-    si2 = s2._stat_indices
-    si1 === nothing && throw(
-        ArgumentError("cannot merge: first FlexiSummary has unknown stat names")
-    )
-    si2 === nothing && throw(
-        ArgumentError("cannot merge: second FlexiSummary has unknown stat names")
-    )
-    names1 = parent(si1)
-    names2 = parent(si2)
-    # Promote key type if necessary
+    # Collect stat names
+    stats1 = parent(s1._stat_indices)
+    stats2 = parent(s2._stat_indices)
+    all_stats = union(stats1, stats2)
+    # Collect key names
     TKeyNew = if TKey1 != TKey2
         new = Base.promote_type(TKey1, TKey2)
         @warn "Merging FlexiSummaries with different key types: $(TKey1) and $(TKey2). The resulting summary will have $(new) as the key type."
@@ -118,37 +113,38 @@ function Base.merge(
     else
         TKey1
     end
-    # Merged stat names and keys: s1's order first, then new from s2
-    merged_names = union(names1, names2)
     all_keys = union(collect(keys(s1._data)), collect(keys(s2._data)))
-    # Build index maps: stat name -> position in original arrays
-    s1_stat_idx = Dict(name => i for (i, name) in enumerate(names1))
-    s2_stat_idx = Dict(name => i for (i, name) in enumerate(names2))
-    # Determine sizes for padding with missing
+    # Build mappings from stat name to index along the 3rd dimension of data array
+    s1_stat_idx = Dict(name => i for (i, name) in enumerate(stats1))
+    s2_stat_idx = Dict(name => i for (i, name) in enumerate(stats2))
+    all_stat_idx = Dict(name => i for (i, name) in enumerate(all_stats))
+    # Determine sizes of output array
     iter_size = s1._iter_indices === nothing ? 1 : length(s1._iter_indices)
     chain_size = s1._chain_indices === nothing ? 1 : length(s1._chain_indices)
-    # Merge data: for each (key, stat), s2 wins if it has the pair
+    stat_size = length(all_stats)
+    # Merge data
     new_data = OrderedDict{ParameterOrExtra{<:TKeyNew}, Array{<:Any, 3}}()
     for k in all_keys
-        arr = Array{Any, 3}(undef, iter_size, chain_size, length(merged_names))
-        fill!(arr, missing)
-        # Fill from s1
+        arr = Array{Any, 3}(missing, iter_size, chain_size, stat_size)
+        # Fill from s1 first.
         if haskey(s1._data, k)
-            for (name, i) in s1_stat_idx
-                j = findfirst(==(name), merged_names)
-                arr[:, :, j] .= @view s1._data[k][:, :, i]
+            # In principle this could be optimised to check if s2 has the combination of key
+            # `k` + stat `name` before filling from s1, but this is probably good enough.
+            for (stat_name, i) in s1_stat_idx
+                j = all_stat_idx[stat_name]
+                arr[:, :, j] = s1._data[k][:, :, i]
             end
         end
-        # Overwrite from s2 (s2 wins)
+        # Then overwrite from s2
         if haskey(s2._data, k)
-            for (name, i) in s2_stat_idx
-                j = findfirst(==(name), merged_names)
+            for (stat_name, i) in s2_stat_idx
+                j = all_stat_idx[stat_name]
                 arr[:, :, j] .= @view s2._data[k][:, :, i]
             end
         end
         new_data[k] = map(identity, arr)
     end
-    new_si = _make_categorical(merged_names)
+    new_si = _make_categorical(all_stats)
     return FlexiSummary{TKeyNew}(
         new_data, s1._iter_indices, s1._chain_indices, new_si, false,
     )

--- a/src/interface/mergesubset.jl
+++ b/src/interface/mergesubset.jl
@@ -145,8 +145,11 @@ function Base.merge(
         new_data[k] = map(identity, arr)
     end
     new_si = _make_categorical(all_stats)
+    # The result should only drop the stat dimension if both inputs dropped it and there's
+    # only one stat in the result (for example, merge(mean(chn1), mean(chn2))).
+    new_drop = s1._drop_stat_dim && s2._drop_stat_dim && length(all_stats) == 1
     return FlexiSummary{TKeyNew}(
-        new_data, s1._iter_indices, s1._chain_indices, new_si, false,
+        new_data, s1._iter_indices, s1._chain_indices, new_si, new_drop,
     )
 end
 

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -15,7 +15,7 @@ end
         TKey,
         TIIdx<:Union{DimensionalData.Lookup,Nothing},
         TCIdx<:Union{DimensionalData.Lookup,Nothing},
-        TSIdx<:Union{DimensionalData.Categorical,Nothing},
+        TSIdx<:DimensionalData.Categorical,
     }
 
 A data structure containing summary statistics of a [`FlexiChain`](@ref).
@@ -67,9 +67,11 @@ Regardless of which dimensions have been collapsed, the internal data of a `Flex
 **always** contains all three dimensions (some of which may have size 1).
 
 Information about which dimensions are collapsed is therefore not stored in the arrays.
-Instead, it is stored in the `_iter_indices`, `_chain_indices`, and `_stat_indices` fields
-of the `FlexiSummary`, as well as their types. If any of these are `nothing`, then that
-dimension has been collapsed.
+Instead, it is stored in the `_iter_indices` and `_chain_indices` fields of the
+`FlexiSummary`, as well as their types. If either of these is `nothing`, then that
+dimension has been collapsed. For the stat dimension, `_stat_indices` always contains a
+`DimensionalData.Categorical` with the stat name(s), but the `_drop_stat_dim` field
+controls whether the stat dimension is presented to the user.
 
 This information is later used in the `_get_raw_data` and `_raw_to_user_data` functions.
 """
@@ -77,7 +79,7 @@ struct FlexiSummary{
         TKey,
         TIIdx <: Union{DD.Lookup, Nothing},
         TCIdx <: Union{DD.Lookup, Nothing},
-        TSIdx <: Union{DD.Categorical, Nothing},
+        TSIdx <: DD.Categorical,
     }
     _data::OrderedDict{ParameterOrExtra{<:TKey}, <:AbstractArray{<:Any, 3}}
     _iter_indices::TIIdx
@@ -97,13 +99,13 @@ struct FlexiSummary{
             TKey,
             TIIdx <: Union{DD.Lookup, Nothing},
             TCIdx <: Union{DD.Lookup, Nothing},
-            TSIdx <: Union{DD.Categorical, Nothing},
+            TSIdx <: DD.Categorical,
         }
         # Get expected size.
         expected_size = (
             TIIdx === Nothing ? 1 : length(iter_indices),
             TCIdx === Nothing ? 1 : length(chain_indices),
-            TSIdx === Nothing ? 1 : length(stat_indices),
+            length(stat_indices),
         )
         # Size verification (while marshalling into a Dict with the right type).
         d = OrderedDict{ParameterOrExtra{<:TKey}, Array{<:Any, 3}}()
@@ -138,14 +140,12 @@ function chain_indices(fs::FlexiSummary{TKey, TIIdx, TCIdx})::TCIdx where {TKey,
     return fs._chain_indices
 end
 """
-    stat_indices(summary::FlexiSummary)::DimensionalData.Lookup
+    stat_indices(summary::FlexiSummary)
 
-The indices for each statistic in the summary. This may be `nothing` if the `$STAT_DIM_NAME` 
-dimension has been collapsed.
+The indices for each statistic in the summary. Returns `nothing` if the `$STAT_DIM_NAME`
+dimension has been collapsed (i.e. `drop_stat_dim=true` was used).
 """
-function stat_indices(
-        fs::FlexiSummary{TKey, TIIdx, TCIdx, TSIdx}
-    )::Union{TSIdx, Nothing} where {TKey, TIIdx, TCIdx, TSIdx}
+function stat_indices(fs::FlexiSummary)
     return fs._drop_stat_dim ? nothing : fs._stat_indices
 end
 

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -83,13 +83,14 @@ struct FlexiSummary{
     _iter_indices::TIIdx
     _chain_indices::TCIdx
     _stat_indices::TSIdx
+    _drop_stat_dim::Bool
 
     function FlexiSummary{TKey}(
             data::OrderedDict{<:Any, <:AbstractArray{<:Any, 3}},
-            # Note: These are NOT keyword arguments, they are mandatory positional arguments
             iter_indices::TIIdx,
             chain_indices::TCIdx,
             stat_indices::TSIdx,
+            drop_stat_dim::Bool,
         )::FlexiSummary{
             TKey, TIIdx, TCIdx, TSIdx,
         } where {
@@ -113,7 +114,9 @@ struct FlexiSummary{
             end
             d[k] = collect(v)
         end
-        return new{TKey, TIIdx, TCIdx, TSIdx}(d, iter_indices, chain_indices, stat_indices)
+        return new{TKey, TIIdx, TCIdx, TSIdx}(
+            d, iter_indices, chain_indices, stat_indices, drop_stat_dim
+        )
     end
 end
 """
@@ -142,8 +145,8 @@ dimension has been collapsed.
 """
 function stat_indices(
         fs::FlexiSummary{TKey, TIIdx, TCIdx, TSIdx}
-    )::TSIdx where {TKey, TIIdx, TCIdx, TSIdx}
-    return fs._stat_indices
+    )::Union{TSIdx, Nothing} where {TKey, TIIdx, TCIdx, TSIdx}
+    return fs._drop_stat_dim ? nothing : fs._stat_indices
 end
 
 _pretty_value(x::Integer, ::Bool = false) = repr(x)
@@ -186,22 +189,23 @@ Returns a tuple of two elements:
 - a tuple of integers corresponding to the dimensions that have been collapsed, which can be
   passed to `dropdims`.
 """
-function _get_summary_dims(
-        fs::FlexiSummary{TKey, TIIdx, TCIdx, TSIdx}
-    ) where {TKey, TIIdx, TCIdx, TSIdx}
+function _get_summary_dims(fs::FlexiSummary)
     new_dims = DD.Dim[]
     dims_to_keep = Int[]
-    if TIIdx !== Nothing
+    ii = iter_indices(fs)
+    ci = chain_indices(fs)
+    si = stat_indices(fs)
+    if ii !== nothing
         push!(dims_to_keep, 1)
-        push!(new_dims, DD.Dim{ITER_DIM_NAME}(iter_indices(fs)))
+        push!(new_dims, DD.Dim{ITER_DIM_NAME}(ii))
     end
-    if TCIdx !== Nothing
+    if ci !== nothing
         push!(dims_to_keep, 2)
-        push!(new_dims, DD.Dim{CHAIN_DIM_NAME}(chain_indices(fs)))
+        push!(new_dims, DD.Dim{CHAIN_DIM_NAME}(ci))
     end
-    if TSIdx !== Nothing
+    if si !== nothing
         push!(dims_to_keep, 3)
-        push!(new_dims, DD.Dim{STAT_DIM_NAME}(stat_indices(fs)))
+        push!(new_dims, DD.Dim{STAT_DIM_NAME}(si))
     end
     dim_indices_to_drop = tuple(setdiff(1:3, dims_to_keep)...)
     return new_dims, dim_indices_to_drop
@@ -257,7 +261,8 @@ with `new_data`.
 """
 function _replace_data(summary::FlexiSummary, ::Type{newkey}, new_data) where {newkey}
     return FlexiSummary{newkey}(
-        new_data, iter_indices(summary), chain_indices(summary), stat_indices(summary)
+        new_data, summary._iter_indices, summary._chain_indices,
+        summary._stat_indices, summary._drop_stat_dim,
     )
 end
 
@@ -415,22 +420,17 @@ function collapse(
             end
         end
     end
+    if drop_stat_dim && length(funcs) != 1
+        throw(
+            ArgumentError(
+                "`drop_stat_dim=true` only allowed when one function is provided"
+            ),
+        )
+    end
     iter_idxs = dims == :chain ? FlexiChains.iter_indices(chain) : nothing
     chain_idxs = dims == :iter ? FlexiChains.chain_indices(chain) : nothing
-    stat_lookup = if drop_stat_dim
-        if length(funcs) != 1
-            throw(
-                ArgumentError(
-                    "`drop_stat_dim=true` only allowed when one function is provided"
-                ),
-            )
-        else
-            nothing
-        end
-    else
-        _make_categorical(names)
-    end
-    return FlexiSummary{TKey}(data, iter_idxs, chain_idxs, stat_lookup)
+    stat_lookup = _make_categorical(names)
+    return FlexiSummary{TKey}(data, iter_idxs, chain_idxs, stat_lookup, drop_stat_dim)
 end
 
 function _stat_docstring(func_name, short_name)

--- a/test/summaries.jl
+++ b/test/summaries.jl
@@ -660,6 +660,223 @@ const WORKS_ON_STRING = [minimum, maximum, prod]
             @test_throws ArgumentError FlexiChains.map_parameters(j, smy)
         end
     end
+
+    @testset "merge FlexiSummary" begin
+        N_iters, N_chains = 10, 3
+        as = rand(N_iters, N_chains)
+        bs = rand(N_iters, N_chains)
+        cs = rand(N_iters, N_chains)
+        chain_ab = FlexiChain{Symbol}(
+            N_iters, N_chains,
+            Dict(Parameter(:a) => as, Parameter(:b) => bs);
+            iter_indices = 2:2:(2 * N_iters),
+            chain_indices = [1, 2, 3],
+        )
+        chain_bc = FlexiChain{Symbol}(
+            N_iters, N_chains,
+            Dict(Parameter(:b) => bs, Extra("c") => cs);
+            iter_indices = 2:2:(2 * N_iters),
+            chain_indices = [1, 2, 3],
+        )
+
+        @testset "same keys, same stats: s2 takes priority" begin
+            s1 = FlexiChains.collapse(chain_ab, [mean, std]; dims = :both)
+            s2 = FlexiChains.collapse(chain_ab, [mean, std]; dims = :both)
+            merged = merge(s1, s2)
+            @test merged isa FlexiSummary{Symbol}
+            for k in keys(s2)
+                @test isequal(merged[k], s2[k])
+            end
+        end
+
+        @testset "disjoint keys, same stats" begin
+            s1 = mean(chain_ab)
+            s2 = mean(chain_bc)
+            merged = merge(s1, s2)
+            @test merged isa FlexiSummary{Symbol}
+            # :a only in s1
+            @test isapprox(merged[:a], s1[:a])
+            # Extra("c") only in s2
+            @test isapprox(merged[Extra("c")], s2[Extra("c")])
+            # :b in both — s2 wins
+            @test isapprox(merged[:b], s2[:b])
+        end
+
+        @testset "same keys, disjoint stats" begin
+            s_mean = mean(chain_ab)
+            s_std = std(chain_ab)
+            merged = merge(s_mean, s_std)
+            @test merged isa FlexiSummary{Symbol}
+            # Both stat names should be present
+            @test FlexiChains.stat_indices(merged) == [:mean, :std]
+            # Values should match the originals
+            @test isapprox(
+                merged[:a, stat = DD.At(:mean)],
+                s_mean[:a],
+            )
+            @test isapprox(
+                merged[:a, stat = DD.At(:std)],
+                s_std[:a],
+            )
+        end
+
+        @testset "disjoint keys and disjoint stats" begin
+            s1 = mean(chain_ab)
+            s2 = std(chain_bc)
+            merged = merge(s1, s2)
+            @test merged isa FlexiSummary{Symbol}
+            @test FlexiChains.stat_indices(merged) == [:mean, :std]
+            # :a only has mean (from s1), std should be missing
+            @test isapprox(merged[:a, stat = DD.At(:mean)], s1[:a])
+            @test ismissing(merged[:a, stat = DD.At(:std)])
+            # Extra("c") only has std (from s2), mean should be missing
+            @test isapprox(merged[Extra("c"), stat = DD.At(:std)], s2[Extra("c")])
+            @test ismissing(merged[Extra("c"), stat = DD.At(:mean)])
+            # :b has mean from s1 and std from s2
+            @test isapprox(merged[:b, stat = DD.At(:mean)], s1[:b])
+            @test isapprox(merged[:b, stat = DD.At(:std)], s2[:b])
+        end
+
+        @testset "overlapping stats: s2 values take priority" begin
+            s1 = FlexiChains.collapse(chain_ab, [mean, std]; dims = :both)
+            chain_ab2 = FlexiChain{Symbol}(
+                N_iters, N_chains,
+                Dict(Parameter(:a) => as .+ 1, Parameter(:b) => bs .+ 1);
+                iter_indices = 2:2:(2 * N_iters),
+                chain_indices = [1, 2, 3],
+            )
+            s2 = mean(chain_ab2)
+            merged = merge(s1, s2)
+            # mean should come from s2 (the shifted data)
+            @test isapprox(merged[:a, stat = DD.At(:mean)], s2[:a])
+            # std should come from s1 (s2 didn't have std)
+            @test isapprox(
+                merged[:a, stat = DD.At(:std)],
+                s1[:a, stat = DD.At(:std)],
+            )
+        end
+
+        @testset "uncollapsed and mismatched iteration or chain indices" begin
+            chain_diff_iter = FlexiChain{Symbol}(
+                N_iters, N_chains,
+                Dict(Parameter(:a) => as);
+                iter_indices = 100:100:(100 * N_iters),
+                chain_indices = [1, 2, 3],
+            )
+            s1 = mean(chain_ab; dims = :chain)
+            s2 = mean(chain_diff_iter; dims = :chain)
+            @test_throws DimensionMismatch merge(s1, s2)
+
+            chain_diff_chain = FlexiChain{Symbol}(
+                N_iters, N_chains,
+                Dict(Parameter(:a) => as);
+                iter_indices = 2:2:(2 * N_iters),
+                chain_indices = [10, 20, 30],
+            )
+            s1 = mean(chain_ab, dims = :iter)
+            s2 = mean(chain_diff_chain, dims = :iter)
+            @test_throws DimensionMismatch merge(s1, s2)
+        end
+
+        @testset "collapsed iter dimension (dims=:iter)" begin
+            s1 = mean(chain_ab; dims = :iter)
+            s2 = std(chain_bc; dims = :iter)
+            merged = merge(s1, s2)
+            @test merged isa FlexiSummary{Symbol}
+            @test FlexiChains.iter_indices(merged) === nothing
+            @test FlexiChains.chain_indices(merged) == FlexiChains.chain_indices(s1)
+        end
+
+        @testset "collapsed chain dimension (dims=:chain)" begin
+            s1 = mean(chain_ab; dims = :chain)
+            s2 = std(chain_bc; dims = :chain)
+            merged = merge(s1, s2)
+            @test merged isa FlexiSummary{Symbol}
+            @test FlexiChains.iter_indices(merged) == FlexiChains.iter_indices(s1)
+            @test FlexiChains.chain_indices(merged) === nothing
+        end
+
+        @testset "dropped stat dim in merge result" begin
+            @testset "when it should be dropped" begin
+                s1 = mean(chain_ab)
+                s2 = mean(chain_bc)
+                @test FlexiChains.stat_indices(s1) === nothing
+                @test FlexiChains.stat_indices(s2) === nothing
+                merged = merge(s1, s2)
+                @test FlexiChains.stat_indices(merged) === nothing
+            end
+            @testset "when it shouldn't be dropped" begin
+                s1 = mean(chain_ab)
+                s2 = std(chain_ab)
+                @test FlexiChains.stat_indices(s1) === nothing
+                @test FlexiChains.stat_indices(s2) === nothing
+                merged = merge(s1, s2)
+                @test FlexiChains.stat_indices(merged) == [:mean, :std]
+            end
+        end
+
+        @testset "key type promotion" begin
+            chain_str = FlexiChain{String}(
+                N_iters, N_chains,
+                Dict(Parameter("x") => rand(N_iters, N_chains));
+                iter_indices = 2:2:(2 * N_iters),
+                chain_indices = [1, 2, 3],
+            )
+            s1 = mean(chain_ab)
+            s2 = mean(chain_str)
+            @test_logs (:warn, r"different key types") merge(s1, s2)
+            merged = merge(s1, s2)
+            @test merged isa FlexiSummary{Any}
+            @test haskey(merged, Parameter(:a))
+            @test haskey(merged, Parameter("x"))
+        end
+
+        @testset "three or more summaries" begin
+            chain_d = FlexiChain{Symbol}(
+                N_iters, N_chains,
+                Dict(Parameter(:d) => rand(N_iters, N_chains));
+                iter_indices = 2:2:(2 * N_iters),
+                chain_indices = [1, 2, 3],
+            )
+            s1 = mean(chain_ab)
+            s2 = mean(chain_bc)
+            s3 = mean(chain_d)
+            merged = merge(s1, s2, s3)
+            @test merged isa FlexiSummary{Symbol}
+            @test haskey(merged, Parameter(:a))
+            @test haskey(merged, Parameter(:b))
+            @test haskey(merged, Extra("c"))
+            @test haskey(merged, Parameter(:d))
+        end
+    end
+
+    @testset "subset_parameters on summary" begin
+        chain_mixed = FlexiChain{Symbol}(
+            N_iters, N_chains,
+            Dict(Parameter(:a) => as, Extra("c") => cs);
+            iter_indices = 2:2:(2 * N_iters),
+            chain_indices = [1, 2, 3],
+        )
+        s = mean(chain_mixed)
+        sp = FlexiChains.subset_parameters(s)
+        @test sp isa FlexiSummary{Symbol}
+        @test haskey(sp, Parameter(:a))
+        @test !haskey(sp, Extra("c"))
+    end
+
+    @testset "subset_extras on summary" begin
+        chain_mixed = FlexiChain{Symbol}(
+            N_iters, N_chains,
+            Dict(Parameter(:a) => as, Extra("c") => cs);
+            iter_indices = 2:2:(2 * N_iters),
+            chain_indices = [1, 2, 3],
+        )
+        s = mean(chain_mixed)
+        se = FlexiChains.subset_extras(s)
+        @test se isa FlexiSummary{Symbol}
+        @test !haskey(se, Parameter(:a))
+        @test haskey(se, Extra("c"))
+    end
 end
 
 end # module


### PR DESCRIPTION
Closes #227 in a backwards-compatible manner

This behaves correctly but it's not ready to merge, it needs docs and tests

```julia
using DynamicPPL, FlexiChains, Distributions, LinearAlgebra, DataFrames, PosteriorStats

@model function test()
    x ~ Normal(0, 1)
    y ~ MvNormal(zeros(2), I)
end
chn = FlexiChains._make_prior_chain(test(), 100, 2)

fs1 = mean(chn)
fs2 = PosteriorStats.hdi(chn; prob=0.95, split_interval=true)
merge(fs1, fs2)

#####################################

julia> fs1 = mean(chn)
╭─FlexiSummary ─────────────────────────────────────────────────────────────────────────────────────╮
│   iter    collapsed                                                                               │
│   chain   collapsed                                                                               │
│   stat    collapsed                                                                               │
│                                                                                                   │
│ Parameters (3) ── VarName                                                                         │
│  Float64  x, y[1], y[2]                                                                           │
│                                                                                                   │
│ Extras (3)                                                                                        │
│  Float64  logprior, loglikelihood, logjoint                                                       │
│                                                                                                   │
│ Summary                                                                                           │
│   param                                                                                           │
│       x   0.0045                                                                                  │
│    y[1]  -0.1303                                                                                  │
│    y[2]  -0.0216                                                                                  │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯

julia> fs2 = PosteriorStats.hdi(chn; prob=0.95, split_interval=true)
╭─FlexiSummary (2 statistics) ──────────────────────────────────────────────────────────────────────╮
│   iter    collapsed                                                                               │
│   chain   collapsed                                                                               │
│ ↓ stat  = [hdi_lower, hdi_upper]                                                                  │
│                                                                                                   │
│ Parameters (3) ── VarName                                                                         │
│  Float64  x, y[1], y[2]                                                                           │
│                                                                                                   │
│ Extras (3)                                                                                        │
│  Float64  logprior, loglikelihood, logjoint                                                       │
│                                                                                                   │
│ Summary                                                                                           │
│   param  hdi_lower  hdi_upper                                                                     │
│       x    -2.0960     1.6336                                                                     │
│    y[1]    -1.8425     1.9051                                                                     │
│    y[2]    -1.7636     2.0575                                                                     │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯

julia> merge(fs1, fs2)
╭─FlexiSummary (3 statistics) ──────────────────────────────────────────────────────────────────────╮
│   iter    collapsed                                                                               │
│   chain   collapsed                                                                               │
│ ↓ stat  = [mean, hdi_lower, hdi_upper]                                                            │
│                                                                                                   │
│ Parameters (3) ── VarName                                                                         │
│  Float64  x, y[1], y[2]                                                                           │
│                                                                                                   │
│ Extras (3)                                                                                        │
│  Float64  logprior, loglikelihood, logjoint                                                       │
│                                                                                                   │
│ Summary                                                                                           │
│   param     mean  hdi_lower  hdi_upper                                                            │
│       x   0.0045    -2.0960     1.6336                                                            │
│    y[1]  -0.1303    -1.8425     1.9051                                                            │
│    y[2]  -0.0216    -1.7636     2.0575                                                            │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
```