### PR TITLE
Re-export Begin/End; document + add error hint

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.6.18
+
+Re-export `Begin` and `End` from DimensionalData.jl, to make indexing into FlexiChains easier.
+
 # 0.6.17
 
 Added the exported alias `SymChain` for `FlexiChain{Symbol}`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
-version = "0.6.17"
+version = "0.6.18"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/indexing.md
+++ b/docs/src/indexing.md
@@ -187,6 +187,13 @@ This is slightly less interesting because chains are always numbered consecutive
 Consequently, `i` and `At(i)` have the same meaning.
 Nonetheless, you can still use all the same selectors as described above, e.g. `Not(2)` to drop the second chain.
 
+Finally, note that regular `begin` and `end` cannot be used with the `iter` and `chain` keyword arguments, because Julia's lowering pass does not handle those appropriately for keyword arguments.
+In place of this you can use `Begin` and `End`, which are [semantically equivalent and re-exported from DimensionalData](@extref DimensionalData Begin-End-indexing).
+
+```@example 1
+chn[@varname(x), iter=(Begin+1):End]
+```
+
 For more information about DimensionalData's selectors, please see [their docs](@extref DimensionalData Selectors).
 
 ### `stack`

--- a/src/FlexiChains.jl
+++ b/src/FlexiChains.jl
@@ -57,8 +57,8 @@ include("plots/shims.jl")
 
 # Convenience re-exports.
 export Wide, Long
-using DimensionalData: At, Near, Contains, (..), Touches, Where, Not, DimArray
-export At, Near, Contains, (..), Touches, Where, Not, DimArray
+using DimensionalData: At, Near, Contains, (..), Touches, Where, Not, DimArray, Begin, End
+export At, Near, Contains, (..), Touches, Where, Not, DimArray, Begin, End
 using Statistics: mean, median, std, var, quantile
 export mean, median, std, var, quantile
 using StatsBase: summarystats, mad
@@ -99,11 +99,19 @@ function _make_posterior_chain end
 end
 
 function __init__()
-    return Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+    Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
         if exc.f === FlexiChains.PlotUtils.get_hdi_intervals
             printstyled(io, "\n\n    To use interval=:hdi, please load PosteriorStats.jl first.\n"; color = :cyan)
         end
     end
+    Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+        if (exc.f === Base.firstindex || exc.f === Base.lastindex) &&
+              length(argtypes) == 1 &&
+            (argtypes[1] <: FlexiChain || argtypes[1] <: FlexiChains.FlexiSummary)
+            printstyled(io, "\n\n    Indexing into FlexiChains objects with `begin` or `end` does not work; please use `Begin` and `End` instead, which are equivalent."; color = :cyan)
+        end
+    end
+    return nothing
 end
 
 end # module FlexiChains

--- a/src/FlexiChains.jl
+++ b/src/FlexiChains.jl
@@ -106,8 +106,8 @@ function __init__()
     end
     Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
         if (exc.f === Base.firstindex || exc.f === Base.lastindex) &&
-              length(argtypes) == 1 &&
-            (argtypes[1] <: FlexiChain || argtypes[1] <: FlexiChains.FlexiSummary)
+                length(argtypes) == 1 &&
+                (argtypes[1] <: FlexiChain || argtypes[1] <: FlexiChains.FlexiSummary)
             printstyled(io, "\n\n    Indexing into FlexiChains objects with `begin` or `end` does not work; please use `Begin` and `End` instead, which are equivalent."; color = :cyan)
         end
     end


### PR DESCRIPTION
Closes #153 properly

Now when someone tries to index with `begin` / `end` they get a friendly error hint:

```julia
julia> chain[iter=1:end]
ERROR: MethodError: no method matching lastindex(::FlexiChains.SymChain{FlexiChains.FlexiChainMetadata{…}})
The function `lastindex` exists, but no method is defined for this combination of argument types.

    Indexing into FlexiChains objects with `begin` or `end` does not work; please use `Begin` and `End` instead, which are equivalent.

Closest candidates are:
  lastindex(::Any, ::Any)
   @ Base abstractarray.jl:427
  lastindex(::Base64.Buffer)
   @ Base64 ~/.julia/juliaup/julia-1.12.6+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/Base64/src/buffer.jl:19
  lastindex(::Markdown.MD)
   @ Markdown ~/.julia/juliaup/julia-1.12.6+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/share/julia/stdlib/v1.12/Markdown/src/parse/parse.jl:33
```