### PR TITLE
Add structures when creating VNChain from Array

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.6.19
+
+Improved the internal structure of `VNChain`s constructed from `Array`s, such that `rand(chn)` returns `DynamicPPL.ParamsWithStats` or `DynamicPPL.VarNamedTuple` (but unfortunately, only if DynamicPPL is loaded, since those types are defined there).
+
 # 0.6.18
 
 Re-export `Begin` and `End` from DimensionalData.jl, to make indexing into FlexiChains easier.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
-version = "0.6.18"
+version = "0.6.19"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/ext/FlexiChainsDynamicPPLExt.jl
+++ b/ext/FlexiChainsDynamicPPLExt.jl
@@ -101,6 +101,18 @@ function FlexiChains.reconstruct_parameters(chn::VNChain, i, j, structure::VarNa
     return vnt
 end
 
+# Overload so that you can construct a VNChain from a 3D array and have it include
+# structures, so that `rand(chn)` returns a more convenient ParamsWithStats rather than a
+# Dict.
+#
+# We only need a skeletal VarNamedTuple. Because all our variables will be top-level
+# symbols, the skeletal VarNamedTuple will be empty, so we don't need to actually construct
+# anything.
+function FlexiChains._make_structures_from_array(::Type{VarName}, niters::Int, nchains::Int)
+    return fill(DynamicPPL.VarNamedTuple(), niters, nchains)
+end
+
+
 ##################################################
 # AbstractMCMC.{to,from}_samples implementations #
 ##################################################

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -1,5 +1,3 @@
-@public FlexiChain, Parameter, Extra, ParameterOrExtra
-@public iter_indices, chain_indices, renumber_iters, renumber_chains
 @public sampling_time, last_sampler_state
 @public get_name
 
@@ -488,11 +486,6 @@ struct FlexiChain{TKey, TMetadata <: FlexiChainMetadata} <: AbstractMCMC.Abstrac
             niters, nchains, iter_indices, chain_indices, sampling_time, last_sampler_state
         )
 
-        # TODO: Allow structures ... ? Seems unlikely that structures would be used by
-        # anything that isn't Turing. Enabling this would be non-breaking though so we can
-        # leave it for a future version.
-        structures = fill(nothing, niters, nchains)
-
         # Handle keys.
         if key_spec isa TKey
             key_spec = (Parameter(key_spec) => (nparams,),)
@@ -506,6 +499,9 @@ struct FlexiChain{TKey, TMetadata <: FlexiChainMetadata} <: AbstractMCMC.Abstrac
                 )
             )
         end
+
+        # Make structures (if possible).
+        structures = _make_structures_from_array(TKey, niters, nchains)
 
         # Construct data
         data = OrderedDict{ParameterOrExtra{<:TKey}, Matrix}()
@@ -526,6 +522,12 @@ struct FlexiChain{TKey, TMetadata <: FlexiChainMetadata} <: AbstractMCMC.Abstrac
         end
         return new{TKey, typeof(metadata)}(data, metadata, structures)
     end
+end
+
+# Default is to not make any structures, but this can be overloaded for TKey = VarName if
+# DynamicPPL is loaded
+function _make_structures_from_array(::Type, niters::Int, nchains::Int)
+    return fill(nothing, niters, nchains)
 end
 
 # note: empty size signifies scalar, not 0-dim array

--- a/test/ext/dynamicppl.jl
+++ b/test/ext/dynamicppl.jl
@@ -602,22 +602,22 @@ _LOGJOINT_KEY = Extra(:logjoint)
     @testset "adds structures when converting from Array" begin
         arr = randn(10, 3, 3)
         for key_spec in (
-            @varname(x),
-            (@varname(x1), @varname(x2), @varname(x3)),
-            (@varname(x1), @varname(x2) => (2,)),
-            (@varname(x1), @varname(x2) => (2,)),
-            (@varname(x1), @varname(x2), Extra(:logp)),
-        )
+                @varname(x),
+                (@varname(x1), @varname(x2), @varname(x3)),
+                (@varname(x1), @varname(x2) => (2,)),
+                (@varname(x1), @varname(x2) => (2,)),
+                (@varname(x1), @varname(x2), Extra(:logp)),
+            )
             chn = FlexiChains.VNChain(arr, @varname(x))
             # Note: this behaviour only works when DynamicPPL is loaded -- be careful about
             # moving this test to anywhere else
             @test rand(chn) isa DynamicPPL.ParamsWithStats
-            @test rand(chn; parameters_only=true) isa DynamicPPL.VarNamedTuple
+            @test rand(chn; parameters_only = true) isa DynamicPPL.VarNamedTuple
 
-            first_values = FlexiChains.values_at(chn; iter=1, chain=1)
+            first_values = FlexiChains.values_at(chn; iter = 1, chain = 1)
             @test first_values isa DynamicPPL.ParamsWithStats
 
-            first_params = FlexiChains.parameters_at(chn; iter=1, chain=1)
+            first_params = FlexiChains.parameters_at(chn; iter = 1, chain = 1)
             @test first_params == first_values.params
         end
     end

--- a/test/ext/dynamicppl.jl
+++ b/test/ext/dynamicppl.jl
@@ -598,6 +598,29 @@ _LOGJOINT_KEY = Extra(:logjoint)
             @test result.loo isa PosteriorStats.PSISLOOResult
         end
     end
+
+    @testset "adds structures when converting from Array" begin
+        arr = randn(10, 3, 3)
+        for key_spec in (
+            @varname(x),
+            (@varname(x1), @varname(x2), @varname(x3)),
+            (@varname(x1), @varname(x2) => (2,)),
+            (@varname(x1), @varname(x2) => (2,)),
+            (@varname(x1), @varname(x2), Extra(:logp)),
+        )
+            chn = FlexiChains.VNChain(arr, @varname(x))
+            # Note: this behaviour only works when DynamicPPL is loaded -- be careful about
+            # moving this test to anywhere else
+            @test rand(chn) isa DynamicPPL.ParamsWithStats
+            @test rand(chn; parameters_only=true) isa DynamicPPL.VarNamedTuple
+
+            first_values = FlexiChains.values_at(chn; iter=1, chain=1)
+            @test first_values isa DynamicPPL.ParamsWithStats
+
+            first_params = FlexiChains.parameters_at(chn; iter=1, chain=1)
+            @test first_params == first_values.params
+        end
+    end
 end
 
 end # module


### PR DESCRIPTION
When creating a VNChain from a 3D array, at present we don't add any structures. That's suboptimal as in principle an empty VarNamedTuple would be plenty and it would allow e.g. `rand(chain)` to return a nice type. However, the problem is that said nice types are in DynamicPPL and so this functionality can't be enabled unless the user has also loaded DynamicPPL. Ideally `ParamsWithStats` and `VarNamedTuple` would be moved to AbstractPPL, but, oh well.