### PR TITLE
Improve performance of flattening & indexing functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# 0.6.24
+
+Improved performance on a number of FlexiChains functions, including the Tables.jl interface.
+
+Fixed a bug where `Wide(::FlexiSummary; parameters_only=false)` would incorrectly yield results where the `Parameter` or `Extra` wrapper was dropped.
+
 # 0.6.23
 
 The plotting functions `pushforward_hist`, `pushforward_continuous`, and `pushforward_discrete` now use Makie's default figure size instead of that determined by `setup_figure_and_layout()`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 version = "0.6.24"
+authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -9,6 +9,7 @@ AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -63,6 +64,7 @@ DynamicPPL = "0.41.6, 0.42"
 InferenceObjects = "0.4"
 IntervalSets = "0.5 - 0.7"
 KernelDensity = "0.6"
+LinearAlgebra = "1"
 MCMCChains = "6, 7"
 MCMCDiagnosticTools = "0.3.15"
 Makie = "0.24"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
-version = "0.6.23"
+version = "0.6.24"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/whynot.md
+++ b/docs/src/whynot.md
@@ -6,34 +6,71 @@ Since I wrote one whole page saying why you _should_ use FlexiChains, here are t
 
 FlexiChains uses dictionaries as its internal storage, and it is fundamentally not type stable to index into a dictionary with an abstract value type.
 Consequently, the vast majority of operations in FlexiChains are not type stable.
-They are potentially also slower than equivalent operations in MCMCChains.
+They can sometimes also be slower than equivalent operations in MCMCChains.
 
-Personally, I consider this to be really unimportant, because chain manipulation and data access are hardly performance bottlenecks in a typical Bayesian workflow.
+Personally, I don't consider this to be important.
+Chain manipulation and data access are hardly performance bottlenecks in a typical Bayesian workflow.
+However, that isn't an excuse for gratuitously poor performance!
 If you find an instance where FlexiChains is unbearably slow, please do open an issue.
+I'm more than happy to look into it, or to suggest ways of working around it.
 
-Note that when interfacing with Turing models, [FlexiChains is typically faster](@ref why-perf).
+### For the interested reader...
+
+Performance differences typically arise because of the different data representation.
+In general, FlexiChains has a richer, more high-level, data structure, which avoids destroying information at early stages of processing.
+In contrast, MCMCChains immediately flattens everything into a 3D array.
+
+If you feed a chain back into a Turing model, e.g. with `predict`, Turing is actually much happier with the high-level, original data representation.
+With MCMCChains you have to pay the cost of 'unflattening'.
+That's why [FlexiChains is typically faster when interfacing with Turing models](@ref why-perf).
+
+Now, flattening is actually quite an expensive operation since it involves essentially reshuffling the entire chain's data in memory and is therefore `O(niters * nchains * nparams)`.
+Generally the means that things that involve flat representations of data (a simple example being conversion to DataFrame) are faster with MCMCChains, because this cost has already been paid upfront.
+With FlexiChains, you have to pay this cost every time you want to do something that requires a flat representation.
+
+```@example flat
+using FlexiChains: FlexiChain, Parameter
+using Chairmarks, DataFrames
+
+niter, nchain, nparam = 1000, 4, 100
+d = [Dict(Parameter(:x) => randn(nparam)) for _ in 1:niter, _ in 1:nchain]
+c = FlexiChain{Symbol}(niter, nchain, d)
+nothing # hide
+```
+
+```@example flat
+# FlexiChains
+@be DataFrame(c) samples=50 evals=1
+```
+
+```@example flat
+using MCMCChains
+m = MCMCChains.Chains(c)
+
+# MCMCChains
+@be DataFrame(m) samples=50 evals=1
+```
+
+However, you should be aware that this is not entirely a fair comparison, and the 'flattening' part of MCMCChains _has already taken place when the chain is constructed_.
+In particular, if you are doing some sampling via `sample(...; chain_type=MCMCChains.Chains)`, note that the chain construction is part of the `sample` call, and thus it will **appear** as if you are just waiting for MCMC sampling to finish, when in fact you are **also** waiting for the chain to be flattened.
+(If you have noticed MCMC sampling often being stuck at 100% for a while, this is why.)
+
+To show a fairer comparison, we can flatten the FlexiChain first.
+Note that `DataFrame(c)` defers to `DataFrame(Wide(c))` (see the [Tables.jl integration section](@ref integrations-tables) for more details).
+The constructor of `Wide` does the flattening for us, so if we pre-compute that, you will find that FlexiChains' performance is not so bad after all!
+
+```@example flat
+using FlexiChains: Wide
+w = Wide(c)
+@be DataFrame(w) samples=50 evals=1
+```
 
 ## Feature set
 
-MCMCChains probably still has more plotting and statistics functions available, even though FlexiChains is catching up quite rapidly.
-This is mainly because MCMCChains has been around for longer, and has had more contributors.
+There are still one or two more plotting and statistics functions that MCMCChains has that FlexiChains does not have yet.
+
+(Note that this isn't entirely a drawback: there are things in FlexiChains that MCMCChains doesn't have too.)
 
 I would be very happy to accept PRs porting some of this functionality to FlexiChains!
 
 In the meantime, you can always [convert your FlexiChain to a `DataFrame`](@ref integrations-tables), or an [`MCMCChains.Chains`](@ref) if you really need to.
-
-## Interface stability
-
-FlexiChains is still quite young, development is happening quite rapidly, and thus its interface may not be fully stable.
-On the other hand MCMCChains is largely stable (although you _may_ consider a lack of development to be a drawback).
-
-My aim is to release a version 1.0 as soon as possible.
-(In general, I strongly subscribe to the view that packages that are used by the public should release 1.0 as soon as possible: see [this issue](https://github.com/JuliaRegistries/General/issues/111019).)
-My preconditions for FlexiChains 1.0 are twofold:
-
- 1. I am happy with the core design and APIs of the package. For example, I don't really care about which statistic functions are implemented, but I do care that they return sensible data structures.
-
- 2. The package has been tested by a people in the wild, to catch any obvious gaps or drawbacks.
-
-As of April 2026, I think that (1) is already satisfied: the data structures and APIs are pretty much where I want them to be, and I expect that future changes will mostly be addition of new functionality rather than breaking changes.
-However, I am still waiting for (2) to really happen, and I would like to see more people using the package and giving feedback before I release 1.0.

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -429,8 +429,8 @@ struct Wide{F<:ChainOrSummary,N<:NamedTuple}
     function Wide(cs::ChainOrSummary; split_varnames::Bool=true, parameters_only::Bool=true)
         cs = _prepare_chain_or_summary(cs; split_varnames, parameters_only)
         # Strip parameter/extra wrappers and convert to Symbol for column names.
-        ks = Tuple(FlexiChains.get_name.(keys(cs)))
-        sym_ks = Symbol.(ks)
+        ks = Tuple(keys(cs))
+        sym_ks = Symbol.(get_name.(ks))
         _check_duplicate_keys(sym_ks)
         symbol_to_keys = NamedTuple{sym_ks}(ks)
         return new{typeof(cs),typeof(symbol_to_keys)}(cs, symbol_to_keys)
@@ -503,11 +503,7 @@ struct Long{F<:FlexiChain,K<:Tuple}
 
     function Long(chn::FlexiChain; split_varnames::Bool=true, parameters_only::Bool=true)
         chn = _prepare_chain_or_summary(chn; split_varnames, parameters_only)
-        original_keys = if parameters_only
-            Tuple(FlexiChains.get_name.(keys(chn)))
-        else
-            Tuple(keys(chn))
-        end
+        original_keys = Tuple(keys(chn))
         _check_duplicate_keys(original_keys)
         return new{typeof(chn),typeof(original_keys)}(chn, original_keys)
     end
@@ -531,7 +527,7 @@ function Tables.getcolumn(s::Wide{<:FlexiChain}, col::Symbol)
     elseif col === FlexiChains.CHAIN_DIM_NAME
         repeat(chain_indices(s.cs); inner=FlexiChains.niters(s.cs))
     else
-        vec(s.cs[s.symbol_to_keys[col]])
+        vec(s.cs._data[s.symbol_to_keys[col]])
     end
 end
 Tables.getcolumn(s::Wide, col::Int) = Tables.getcolumn(s, Tables.columnnames(s)[col])

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -55,6 +55,7 @@ function _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:Cholesky}
     s = size(first(data))
     return all(x -> size(x) == s, data)
 end
+_elems_have_fixed_vn_leaves(::Array) = false  # Fallback.
 
 """
     FlexiChains._split_varnames(cs::ChainOrSummary{Union{Symbol,<:AbstractString}})

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -551,8 +551,7 @@ function Tables.getcolumn(s::Wide{<:FlexiChain}, col::Symbol)
     else
         # Because the chain has been constructed via `_prepare_chain_or_summary`, we know
         # that `s.symbol_to_keys[col]` is actually a legitimate key in the raw data
-        # dictionary, so we can index directly into the data dict instead of the chain. This
-        # causes a huge performance improvement.
+        # dictionary, so we can index directly into the data dict instead of the chain.
         vec(s.cs._data[s.symbol_to_keys[col]])
     end
 end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -25,8 +25,6 @@ function _split_varnames(cs::ChainOrSummary{<:VarName})
             for vn_leaf in AbstractPPL.varname_leaves(vn, first(d))
                 push!(vns, vn_leaf)
             end
-            # TODO: can we have more shortcircuits for scalars or other things? This is an
-            # obvious spot for perf improvements!
         else
             for i in eachindex(d)
                 for vn_leaf in AbstractPPL.varname_leaves(vn, d[i])
@@ -41,6 +39,8 @@ end
 # This helper function identifies cases where we don't need to check every single Niters x
 # Nchains elements, because they all have the same structure.
 _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:Real} = !isempty(data)
+_elems_have_fixed_vn_leaves(data::Array{T}) where {T<:AbstractString} = !isempty(data)
+_elems_have_fixed_vn_leaves(data::Array{Symbol}) = !isempty(data)
 function _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:AbstractArray}
     # If `T` is not even a concrete type, e.g. it's a Union of two different
     # AbstractArray types, then we have no hope.
@@ -52,8 +52,10 @@ function _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:AbstractArray}
 end
 function _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:Cholesky}
     (isconcretetype(T) && !isempty(data)) || return false
-    s = size(first(data))
-    return all(x -> size(x) == s, data)
+    f = first(data)
+    a = axes(f)
+    ul = f.uplo
+    return all(x -> axes(x) == a && x.uplo == ul, data)
 end
 _elems_have_fixed_vn_leaves(::Array) = false  # Fallback.
 

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -621,15 +621,14 @@ function Tables.getcolumn(w::Wide{<:FlexiSummary}, col::Symbol)
                 # but avoids the overhead of the getindex call when we know for certain
                 # that `k` is already a valid key in `w.cs._data`.
                 idx = findfirst(==(col), parent(si))
-                get_stat_val(k) = w.cs._data[k][1, 1, idx]
+                get_stat_val(k) = w.cs._data[k][:, :, idx]
                 if ii === nothing && ci === nothing
-                    [get_stat_val(k) for k in values(w.symbol_to_keys)]
+                    # get_stat_val returns 1x1x1 array
+                    [get_stat_val(k)[] for k in values(w.symbol_to_keys)]
                 else
-                    vcat(
-                        [
-                            parent(w.cs[k, stat=At(col)]) for k in values(w.symbol_to_keys)
-                        ]...,
-                    )
+                    # get_stat_val returns iters x 1 x 1 array or 1 x nchains x 1 array
+                    stat_vals = [vec(get_stat_val(k)) for k in values(w.symbol_to_keys)]
+                    vcat(stat_vals...)
                 end
             else
                 throw(

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -503,7 +503,11 @@ struct Long{F<:FlexiChain,K<:Tuple}
 
     function Long(chn::FlexiChain; split_varnames::Bool=true, parameters_only::Bool=true)
         chn = _prepare_chain_or_summary(chn; split_varnames, parameters_only)
-        original_keys = Tuple(keys(chn))
+        original_keys = if parameters_only
+            Tuple(FlexiChains.get_name.(keys(chn)))
+        else
+            Tuple(keys(chn))
+        end
         _check_duplicate_keys(original_keys)
         return new{typeof(chn),typeof(original_keys)}(chn, original_keys)
     end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -18,7 +18,9 @@ function _split_varnames(cs::ChainOrSummary{<:VarName})
     for vn in FlexiChains.parameters(cs)
         d = _get_raw_data(cs, Parameter(vn))
         if _is_fixed_size_array_data(d)
-            # Don't need to iterate over all matrix elements - just check the first one.
+            # Don't need to iterate over all array elements - just check the first one.
+            # (Note that `d` could be Array{T,2} or Array{T,3} depending on whether `cs` is
+            # a chain or summary.)
             for vn_leaf in AbstractPPL.varname_leaves(vn, first(d))
                 push!(vns, vn_leaf)
             end
@@ -35,7 +37,7 @@ function _split_varnames(cs::ChainOrSummary{<:VarName})
     return cs[[collect(vns)..., FlexiChains.extras(cs)...]]
 end
 
-function _is_fixed_size_array_data(data::Matrix{T}) where {T}
+function _is_fixed_size_array_data(data::Array{T}) where {T}
     # Returns true if every entry in `data` is an array of the same size.
     (isconcretetype(T) && T <: AbstractArray && !isempty(data)) || return false
     sz = size(first(data))
@@ -499,17 +501,17 @@ table.
 struct Long{F<:FlexiChain,K<:Tuple}
     chn::F
     # The keys for the param column: unwrapped if parameters_only, wrapped otherwise.
-    original_keys::K
+    maybe_unwrapped_keys::K
 
     function Long(chn::FlexiChain; split_varnames::Bool=true, parameters_only::Bool=true)
         chn = _prepare_chain_or_summary(chn; split_varnames, parameters_only)
-        original_keys = if parameters_only
+        maybe_unwrapped_keys = if parameters_only
             Tuple(FlexiChains.get_name.(keys(chn)))
         else
             Tuple(keys(chn))
         end
-        _check_duplicate_keys(original_keys)
-        return new{typeof(chn),typeof(original_keys)}(chn, original_keys)
+        _check_duplicate_keys(maybe_unwrapped_keys)
+        return new{typeof(chn),typeof(maybe_unwrapped_keys)}(chn, maybe_unwrapped_keys)
     end
 end
 
@@ -636,20 +638,23 @@ Tables.columnnames(::Long) = [
     VALUE_COL_NAME,
 ]
 function Tables.getcolumn(s::Long, col::Symbol)
-    nkeys = length(s.original_keys)
+    nkeys = length(s.maybe_unwrapped_keys)
     return if col === FlexiChains.ITER_DIM_NAME
         repeat(iter_indices(s.chn); outer=FlexiChains.nchains(s.chn) * nkeys)
     elseif col === FlexiChains.CHAIN_DIM_NAME
         repeat(chain_indices(s.chn); inner=FlexiChains.niters(s.chn), outer=nkeys)
     elseif col === FlexiChains.PARAM_DIM_NAME
         repeat(
-            collect(s.original_keys);
+            collect(s.maybe_unwrapped_keys);
             inner=FlexiChains.niters(s.chn) * FlexiChains.nchains(s.chn),
         )
     elseif col === VALUE_COL_NAME
-        mapreduce(vcat, s.original_keys) do k
-            vec(s.chn[k])
+        # mapreduce(vcat, ...) is very slow (presumably quadratic behaviour?)
+        vs = map(s.maybe_unwrapped_keys) do k
+            wrapped_key = k isa ParameterOrExtra ? k : Parameter(k)
+            vec(s.chn._data[wrapped_key])
         end
+        vcat(vs...)
     else
         throw(ArgumentError("unknown column name: $col"))
     end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -597,9 +597,9 @@ function Tables.getcolumn(w::Wide{<:FlexiSummary}, col::Symbol)
     elseif col === FlexiChains.STAT_DIM_NAME
         if si === nothing
             if ii === nothing && ci === nothing
-                [w.cs._data[k] for k in values(w.symbol_to_keys)]
+                [w.cs._data[k][] for k in values(w.symbol_to_keys)]
             else
-                vcat([parent(w.cs._data[k]) for k in values(w.symbol_to_keys)]...)
+                vcat([vec(w.cs._data[k]) for k in values(w.symbol_to_keys)]...)
             end
         else
             throw(

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -425,8 +425,12 @@ julia> df = DataFrame(Wide(mean(chn)))
 """
 struct Wide{F<:ChainOrSummary,N<:NamedTuple}
     cs::F
-    # A precomputed mapping from Symbol(k) => k for all keys in `cs`.
+    # A precomputed mapping from Symbol(get_name(k)) => k for all keys in `cs`.
     symbol_to_keys::N
+    # For summaries, a flag to indicate whether or not the keys should be unwrapped
+    # for the param column. This isn't an issue for chains because Wide(chn) doesn't
+    # have a param column
+    parameters_only::Bool
 
     function Wide(cs::ChainOrSummary; split_varnames::Bool=true, parameters_only::Bool=true)
         cs = _prepare_chain_or_summary(cs; split_varnames, parameters_only)
@@ -435,7 +439,7 @@ struct Wide{F<:ChainOrSummary,N<:NamedTuple}
         sym_ks = Symbol.(get_name.(ks))
         _check_duplicate_keys(sym_ks)
         symbol_to_keys = NamedTuple{sym_ks}(ks)
-        return new{typeof(cs),typeof(symbol_to_keys)}(cs, symbol_to_keys)
+        return new{typeof(cs),typeof(symbol_to_keys)}(cs, symbol_to_keys, parameters_only)
     end
 end
 
@@ -576,6 +580,9 @@ function Tables.getcolumn(w::Wide{<:FlexiSummary}, col::Symbol)
     nparams = length(w.symbol_to_keys)
     return if col === FlexiChains.PARAM_DIM_NAME
         ks = collect(values(w.symbol_to_keys))
+        if w.parameters_only
+            ks = FlexiChains.get_name.(ks)
+        end
         repeat(ks; inner=nic)
     elseif col === FlexiChains.ITER_DIM_NAME
         ii === nothing && throw(
@@ -590,9 +597,9 @@ function Tables.getcolumn(w::Wide{<:FlexiSummary}, col::Symbol)
     elseif col === FlexiChains.STAT_DIM_NAME
         if si === nothing
             if ii === nothing && ci === nothing
-                [w.cs[k] for k in values(w.symbol_to_keys)]
+                [w.cs._data[k] for k in values(w.symbol_to_keys)]
             else
-                vcat([parent(w.cs[k]) for k in values(w.symbol_to_keys)]...)
+                vcat([parent(w.cs._data[k]) for k in values(w.symbol_to_keys)]...)
             end
         else
             throw(
@@ -609,8 +616,14 @@ function Tables.getcolumn(w::Wide{<:FlexiSummary}, col::Symbol)
             )
         else
             if col in parent(si)
+                # Perf optimisation. This is equivalent to
+                #     get_stat_val(k) = w.cs[k, stat=At(col)]
+                # but avoids the overhead of the getindex call when we know for certain
+                # that `k` is already a valid key in `w.cs._data`.
+                idx = findfirst(==(col), parent(si))
+                get_stat_val(k) = w.cs._data[k][1, 1, idx]
                 if ii === nothing && ci === nothing
-                    [w.cs[k, stat=At(col)] for k in values(w.symbol_to_keys)]
+                    [get_stat_val(k) for k in values(w.symbol_to_keys)]
                 else
                     vcat(
                         [

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -527,6 +527,10 @@ function Tables.getcolumn(s::Wide{<:FlexiChain}, col::Symbol)
     elseif col === FlexiChains.CHAIN_DIM_NAME
         repeat(chain_indices(s.cs); inner=FlexiChains.niters(s.cs))
     else
+        # Because the chain has been constructed via `_prepare_chain_or_summary`, we know
+        # that `s.symbol_to_keys[col]` is actually a legitimate key in the raw data
+        # dictionary, so we can index directly into the data dict instead of the chain. This
+        # causes a huge performance improvement.
         vec(s.cs._data[s.symbol_to_keys[col]])
     end
 end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,5 +1,6 @@
 # Utilities for 'flattening' chains.
 import Tables
+using LinearAlgebra: Cholesky
 
 """
     FlexiChains._split_varnames(cs::ChainOrSummary{<:VarName})
@@ -17,7 +18,7 @@ function _split_varnames(cs::ChainOrSummary{<:VarName})
     vns = OrderedSet{VarName}()
     for vn in FlexiChains.parameters(cs)
         d = _get_raw_data(cs, Parameter(vn))
-        if _is_fixed_size_array_data(d)
+        if _elems_have_fixed_vn_leaves(d)
             # Don't need to iterate over all array elements - just check the first one.
             # (Note that `d` could be Array{T,2} or Array{T,3} depending on whether `cs` is
             # a chain or summary.)
@@ -37,11 +38,22 @@ function _split_varnames(cs::ChainOrSummary{<:VarName})
     return cs[[collect(vns)..., FlexiChains.extras(cs)...]]
 end
 
-function _is_fixed_size_array_data(data::Array{T}) where {T}
-    # Returns true if every entry in `data` is an array of the same size.
-    (isconcretetype(T) && T <: AbstractArray && !isempty(data)) || return false
-    sz = size(first(data))
-    return all(x -> size(x) == sz, data)
+# This helper function identifies cases where we don't need to check every single Niters x
+# Nchains elements, because they all have the same structure.
+_elems_have_fixed_vn_leaves(data::Array{T}) where {T<:Real} = !isempty(data)
+function _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:AbstractArray}
+    # If `T` is not even a concrete type, e.g. it's a Union of two different
+    # AbstractArray types, then we have no hope.
+    (isconcretetype(T) && !isempty(data)) || return false
+    # Checking axes is no less expensive than checking size, and axes works better because
+    # it catches things like OffsetArrays which have the same size but different offsets.
+    a = axes(first(data))
+    return all(x -> axes(x) == a, data)
+end
+function _elems_have_fixed_vn_leaves(data::Array{T}) where {T<:Cholesky}
+    (isconcretetype(T) && !isempty(data)) || return false
+    s = size(first(data))
+    return all(x -> size(x) == s, data)
 end
 
 """

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -17,13 +17,29 @@ function _split_varnames(cs::ChainOrSummary{<:VarName})
     vns = OrderedSet{VarName}()
     for vn in FlexiChains.parameters(cs)
         d = _get_raw_data(cs, Parameter(vn))
-        for i in eachindex(d)
-            for vn_leaf in AbstractPPL.varname_leaves(vn, d[i])
+        if _is_fixed_size_array_data(d)
+            # Don't need to iterate over all matrix elements - just check the first one.
+            for vn_leaf in AbstractPPL.varname_leaves(vn, first(d))
                 push!(vns, vn_leaf)
+            end
+            # TODO: can we have more shortcircuits for scalars or other things? This is an
+            # obvious spot for perf improvements!
+        else
+            for i in eachindex(d)
+                for vn_leaf in AbstractPPL.varname_leaves(vn, d[i])
+                    push!(vns, vn_leaf)
+                end
             end
         end
     end
     return cs[[collect(vns)..., FlexiChains.extras(cs)...]]
+end
+
+function _is_fixed_size_array_data(data::Matrix{T}) where {T}
+    # Returns true if every entry in `data` is an array of the same size.
+    (isconcretetype(T) && T <: AbstractArray && !isempty(data)) || return false
+    sz = size(first(data))
+    return all(x -> size(x) == sz, data)
 end
 
 """

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -102,7 +102,11 @@ function _get_raw_data(cs::ChainOrSummary{<:VarName}, vn_param::Parameter{<:VarN
     )
     # can't use get_raw_data in this line or else it will recurse.
     raw = cs._data[Parameter(vn)]
-    return _map_optic(optic, raw, orig_vn)
+    return if optic isa AbstractPPL.Iden
+        raw # No need to do the mapping
+    else
+        _map_optic(optic, raw, orig_vn)
+    end
 end
 
 """

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -93,6 +93,10 @@ end
 Overloaded method which provides extra functionality when indexing by VarNames.
 """
 function _get_raw_data(cs::ChainOrSummary{<:VarName}, vn_param::Parameter{<:VarName})
+    # Shortcircuit if the VarName is already present as-is (this can save quite a bit of
+    # time in tight loops)
+    haskey(cs._data, vn_param) && return cs._data[vn_param]
+    # Otherwise we might need to split up the VarName into a prefix + an optic.
     orig_vn = vn_param.name
     optic, vn = _getindex_optic_and_vn(
         FlexiChains.parameters(cs),
@@ -100,13 +104,9 @@ function _get_raw_data(cs::ChainOrSummary{<:VarName}, vn_param::Parameter{<:VarN
         AbstractPPL.Iden(),
         orig_vn,
     )
-    # can't use get_raw_data in this line or else it will recurse.
+    # Can't use get_raw_data in this line or else it will recurse.
     raw = cs._data[Parameter(vn)]
-    return if optic isa AbstractPPL.Iden
-        raw # No need to do the mapping
-    else
-        _map_optic(optic, raw, orig_vn)
-    end
+    return _map_optic(optic, raw, orig_vn)
 end
 
 """

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -442,7 +442,7 @@ using FlexiChains: Tables
                 fs = mean(sc)
                 df = DataFrame(Wide(fs; parameters_only=false))
                 @test nrow(df) == 3
-                @test :lp in df.param
+                @test Extra(:lp) in df.param
             end
 
             @testset "VarName-keyed summary with array-valued param" begin


### PR DESCRIPTION
Closes #271.

```julia
using FlexiChains: FlexiChain, Parameter, Wide, Long, @varname, VarName, summarystats
using DataFrames
niter, nchain, nparam = 1000, 4, 1000
d = [Dict(
    Parameter(@varname(x)) => randn(nparam)
) for _ in 1:niter, _ in 1:nchain];
c = FlexiChain{VarName}(niter, nchain, d)
```

Before this PR:

```julia
julia> @time DataFrame(Wide(c)); # First time
  1.783885 seconds (34.64 M allocations: 1.103 GiB, 16.07% gc time, 57.70% compilation time: 1% of which was recompilation)

julia> @time DataFrame(Wide(c)); # Subsequent
  0.628316 seconds (26.31 M allocations: 730.417 MiB, 23.15% gc time)

julia> @time DataFrame(Long(c)); # First time
  3.368797 seconds (26.81 M allocations: 15.839 GiB, 56.02% gc time, 2.87% compilation time)

julia> @time DataFrame(Long(c)); # Subsequent
  2.741389 seconds (26.29 M allocations: 15.814 GiB, 50.70% gc time)

julia> @time s = summarystats(c); # First time
  1.381103 seconds (26.38 M allocations: 1.829 GiB, 11.29% gc time, 42.15% compilation time: 14% of which was recompilation)

julia> @time s = summarystats(c); # Subsequent
  0.654736 seconds (21.34 M allocations: 1.586 GiB, 4.41% gc time)

julia> @time DataFrame(Wide(s)); # First time
  4.514657 seconds (105.19 M allocations: 3.131 GiB, 3.26% gc time, 7.21% compilation time)

julia> @time DataFrame(Wide(s)); # Subsequent
  4.142740 seconds (102.52 M allocations: 3.003 GiB, 3.34% gc time)
```

With this PR:

```julia
julia> @time DataFrame(Wide(c)); # First time
  1.220366 seconds (8.31 M allocations: 510.018 MiB, 22.75% gc time, 86.63% compilation time: 1% of which was recompilation)

julia> @time DataFrame(Wide(c)); # Subsequent
  0.034944 seconds (65.89 k allocations: 127.342 MiB, 11.26% gc time)

julia> @time DataFrame(Long(c)); # First time
  0.444700 seconds (845.73 k allocations: 378.129 MiB, 58.94% gc time, 32.78% compilation time)

julia> @time DataFrame(Long(c)); # Subsequent
  0.172858 seconds (46.89 k allocations: 339.512 MiB, 80.39% gc time)

julia> @time s = summarystats(c); # First time
  1.314114 seconds (5.92 M allocations: 1.473 GiB, 20.43% gc time, 44.70% compilation time: 16% of which was recompilation)

julia> @time s = summarystats(c); # Subsequent
  0.474143 seconds (631.94 k allocations: 1.218 GiB, 3.83% gc time)

julia> @time DataFrame(Wide(s)); # First time
  0.300927 seconds (2.30 M allocations: 106.414 MiB, 2.11% gc time, 97.28% compilation time)

julia> @time DataFrame(Wide(s)); # Subsequent
  0.007812 seconds (306.93 k allocations: 8.574 MiB)
```