### PR TITLE
Update MCMCChains extension

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 0.6.28
+
+Added a function `FlexiChains.from_mcmcchains` to convert from an `MCMCChains.Chains` object.
+This supersedes the previous `FlexiChain{Symbol}(::MCMCChains.Chains)` constructor, which is now deprecated.
+
 # 0.6.27
 
 Added a function `FlexiChains.from_pigeons` to convert a Pigeons.jl sampling result into a `FlexiChain`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.27"
+version = "0.6.28"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,16 +41,16 @@ links = InterLinks(
 
 modules = [
     FlexiChains,
-    Base.get_extension(FlexiChains, :FlexiChainsPosteriorDBExt),
-    Base.get_extension(FlexiChains, :FlexiChainsPosteriorStatsExt),
     Base.get_extension(FlexiChains, :FlexiChainsDynamicPPLExt),
     Base.get_extension(FlexiChains, :FlexiChainsInferenceObjectsExt),
+    Base.get_extension(FlexiChains, :FlexiChainsMCMCChainsExt),
     Base.get_extension(FlexiChains, :FlexiChainsMakieExt),
     Base.get_extension(FlexiChains, :FlexiChainsPairPlotsExt),
     Base.get_extension(FlexiChains, :FlexiChainsPigeonsExt),
+    Base.get_extension(FlexiChains, :FlexiChainsPosteriorDBExt),
     Base.get_extension(FlexiChains, :FlexiChainsPosteriorStatsDynamicPPLExt),
+    Base.get_extension(FlexiChains, :FlexiChainsPosteriorStatsExt),
     Base.get_extension(FlexiChains, :FlexiChainsRecipesBaseExt),
-    Base.get_extension(FlexiChains, :FlexiChainsMCMCChainsExt),
     Base.get_extension(FlexiChains, :FlexiChainsStatsPlotsExt),
 ]
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -147,7 +147,6 @@ DynamicPPL.pointwise_logdensities
 DynamicPPL.pointwise_loglikelihoods
 DynamicPPL.pointwise_prior_logdensities
 DynamicPPL.InitFromParams
-MCMCChains.Chains
 AbstractMCMC.from_samples
 AbstractMCMC.to_samples
 ```

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -1,7 +1,7 @@
 # Integrations with other packages
 
-FlexiChains is most obviously tied to the Turing.jl ecosystem, as described on the previous pages.
-However, it also contains some useful links to other packages (listed here in alphabetical order).
+FlexiChains is most obviously tied to the Turing.jl ecosystem.
+However, it also contains a number of functions and extensions to work with other packages (listed here in alphabetical order).
 
 ## (Your custom sampler here...!)
 
@@ -168,6 +168,18 @@ If you try this and find that something doesn't work, please do feel free to ope
 
 `FlexiChain` and `FlexiSummary` objects can be serialised with JLD2.jl with no fuss.
 See [the Serialization section below](@ref integrations-serialization) for an example.
+
+## MCMCChains.jl
+
+You can convert to and from `MCMCChains.Chains` objects using the following functions:
+
+```@docs
+FlexiChains.from_mcmcchains
+MCMCChains.Chains(::FlexiChains.FlexiChain)
+```
+
+Note that the constructor `FlexiChain{Symbol}(c::MCMCChains.Chains)` is deprecated.
+In its place you can use `FlexiChains.from_mcmcchains(c)`, which has exactly the same behaviour.
 
 ## [PairPlots.jl](@id integrations-pairplots)
 

--- a/ext/FlexiChainsMCMCChainsExt.jl
+++ b/ext/FlexiChainsMCMCChainsExt.jl
@@ -118,7 +118,7 @@ function _infer_key_type(key_spec::Tuple)
     return Symbol
 end
 
-# Deprecated: use FlexiChains.from_mcmcchains(chains) instead.
+# I can't seem to get Base.@deprecate to work
 function FlexiChains.FlexiChain{Symbol}(chains::MCMCChains.Chains)
     Base.depwarn(
         "`FlexiChain{Symbol}(chains::MCMCChains.Chains)` is deprecated, use `FlexiChains.from_mcmcchains(chains)` instead.",

--- a/ext/FlexiChainsMCMCChainsExt.jl
+++ b/ext/FlexiChainsMCMCChainsExt.jl
@@ -24,13 +24,17 @@ If `key_spec` is not provided, parameters in the `:parameters` section are store
 giving a `FlexiChain{Symbol}`.
 
 If `key_spec` is provided, it is passed directly to the `FlexiChain` from-array constructor.
-The key type of the resulting `FlexiChain` is inferred from `key_spec`.
+The key type of the resulting `FlexiChain` is inferred from `key_spec`. You can pass this
+argument if you want to override the parameter names stored in the `MCMCChains.Chains`
+object, or to group array-valued parameters together, for example.
 
 Please see [the `FlexiChain` constructor documentation](@ref
 FlexiChains.FlexiChain(::AbstractArray{T,3}, key_spec) where {T}) for details on what
 `key_spec` is allowed.
 
-Iteration indices, chain indices, and per-chain sampling times are preserved where possible.
+Iteration indices, chain indices, and per-chain sampling times are inherited from the
+`MCMCChains.Chains` object. If the `MCMCChains.Chains` object contains a `samplerstate`
+field in its `info` NamedTuple, this is also preserved in the resulting FlexiChain.
 """
 function FlexiChains.from_mcmcchains(
     chains::MCMCChains.Chains,

--- a/ext/FlexiChainsMCMCChainsExt.jl
+++ b/ext/FlexiChainsMCMCChainsExt.jl
@@ -26,6 +26,10 @@ giving a `FlexiChain{Symbol}`.
 If `key_spec` is provided, it is passed directly to the `FlexiChain` from-array constructor.
 The key type of the resulting `FlexiChain` is inferred from `key_spec`.
 
+Please see [the `FlexiChain` constructor documentation](@ref
+FlexiChains.FlexiChain(::AbstractArray{T,3}, key_spec) where {T}) for details on what
+`key_spec` is allowed.
+
 Iteration indices, chain indices, and per-chain sampling times are preserved where possible.
 """
 function FlexiChains.from_mcmcchains(

--- a/ext/FlexiChainsMCMCChainsExt.jl
+++ b/ext/FlexiChainsMCMCChainsExt.jl
@@ -1,6 +1,6 @@
 module FlexiChainsMCMCChainsExt
 
-using FlexiChains: FlexiChains, FlexiChain, VarName, AbstractPPL
+using FlexiChains: FlexiChains, FlexiChain, VarName, AbstractPPL, Parameter, Extra
 using MCMCChains: MCMCChains
 using OrderedCollections: OrderedDict, OrderedSet
 
@@ -15,43 +15,43 @@ const MCSamplerStateKey = :samplerstate
 ##############################
 
 """
-    FlexiChain{Symbol}(chains::MCMCChains.Chains)
+    FlexiChains.from_mcmcchains(chains::MCMCChains.Chains, key_spec=nothing)
 
-Convert an `MCMCChains.Chains` object to a `FlexiChain{Symbol}`.
+Convert an `MCMCChains.Chains` object to a `FlexiChain`.
 
-Parameters in the `:parameters` section of the `Chains` are stored as `Parameter{Symbol}`
-keys, while parameters in all other sections (e.g. `:internals`) are stored as `Extra` keys.
+If `key_spec` is not provided, parameters in the `:parameters` section are stored as
+`Parameter{Symbol}` keys and all other sections (e.g. `:internals`) as `Extra{Symbol}` keys,
+giving a `FlexiChain{Symbol}`.
+
+If `key_spec` is provided, it is passed directly to the `FlexiChain` from-array constructor.
+The key type of the resulting `FlexiChain` is inferred from `key_spec`.
 
 Iteration indices, chain indices, and per-chain sampling times are preserved where possible.
 """
-function FlexiChains.FlexiChain{Symbol}(chains::MCMCChains.Chains)
+function FlexiChains.from_mcmcchains(
+    chains::MCMCChains.Chains,
+    key_spec::Union{Nothing,Tuple}=nothing,
+)
     ni, _, nc = size(chains)
-    iter_indices = Base.range(chains)
-    chain_indices = MCMCChains.chains(chains) # bizarre function name, yeah
+    # MCMCChains stores data as (niters, nparams, nchains); the FlexiChain from-array
+    # constructor expects (niters, nchains, nparams).
+    arr = permutedims(chains.value.data, (1, 3, 2))
 
-    data = OrderedDict{FlexiChains.ParameterOrExtra{Symbol},Matrix}()
-
-    # Parameters section
-    param_names = if haskey(chains.name_map, :parameters)
-        chains.name_map[:parameters]
-    else
-        Symbol[]
-    end
-    for name in param_names
-        var_idx = findfirst(==(name), Base.names(chains))
-        var_idx === nothing && continue
-        data[FlexiChains.Parameter(name)] = chains.value.data[:, var_idx, :]
-    end
-
-    # All other sections become Extras.
-    for section in keys(chains.name_map)
-        section === :parameters && continue
-        for name in chains.name_map[section]
-            var_idx = findfirst(==(name), Base.names(chains))
-            var_idx === nothing && continue
-            data[FlexiChains.Extra(name)] = chains.value.data[:, var_idx, :]
+    # If no key_spec is provided, build one from the MCMCChains name_map. The :parameters
+    # section becomes Parameter keys, everything else becomes Extra keys.
+    if key_spec === nothing
+        param_names = get(chains.name_map, :parameters, Symbol[])
+        other_names = Iterators.flatmap(keys(chains.name_map)) do section
+            section === :parameters ? Symbol[] : chains.name_map[section]
         end
+        key_spec = tuple(
+            (Parameter(n) for n in param_names)...,
+            (Extra(n) for n in other_names)...,
+        )
     end
+
+    iter_indices = collect(Int, Base.range(chains))
+    chain_indices = collect(Int, MCMCChains.chains(chains))  # bizarre function name, yeah
 
     # Attempt to determine whether the chain was constructed with `sample(model, spl, N)` or
     # `sample(model, spl, MCMCThreads(), N, M)`. This affects whether the metadata is
@@ -89,15 +89,34 @@ function FlexiChains.FlexiChain{Symbol}(chains::MCMCChains.Chains)
         fill(missing, nc)
     end
 
-    return FlexiChains.FlexiChain{Symbol}(
-        ni,
-        nc,
-        data;
+    TKey = _infer_key_type(key_spec)
+    return FlexiChain{TKey}(
+        arr,
+        key_spec;
         iter_indices=iter_indices,
         chain_indices=chain_indices,
         sampling_time=sampling_time,
         last_sampler_state=last_sampler_state,
     )
+end
+
+function _infer_key_type(key_spec::Tuple)
+    for k in key_spec
+        key = k isa Pair ? first(k) : k
+        if key isa Parameter
+            return typeof(key).parameters[1]
+        end
+    end
+    return Symbol
+end
+
+# Deprecated: use FlexiChains.from_mcmcchains(chains) instead.
+function FlexiChains.FlexiChain{Symbol}(chains::MCMCChains.Chains)
+    Base.depwarn(
+        "`FlexiChain{Symbol}(chains::MCMCChains.Chains)` is deprecated, use `FlexiChains.from_mcmcchains(chains)` instead.",
+        :FlexiChain,
+    )
+    return FlexiChains.from_mcmcchains(chains)
 end
 
 ############################

--- a/src/FlexiChains.jl
+++ b/src/FlexiChains.jl
@@ -56,6 +56,10 @@ include("plots/plots.jl")
 include("plots/makie.jl")
 include("plots/shims.jl")
 
+# Extended in MCMCChains extension
+function from_mcmcchains end
+@public from_mcmcchains
+
 # Extended in Pigeons extension
 function from_pigeons end
 @public from_pigeons

--- a/test/ext/mcmcchains.jl
+++ b/test/ext/mcmcchains.jl
@@ -1,10 +1,46 @@
 module FlexiChainsMCMCChainsExtTests
 
+using AbstractMCMC: AbstractMCMC
 using DimensionalData: DimArray, Dim
-using FlexiChains: FlexiChains, FlexiChain, VNChain, Parameter, Extra, ParameterOrExtra
-using AbstractMCMC
+using Distributions
+using DynamicPPL
+using FlexiChains:
+    FlexiChains, FlexiChain, VNChain, Parameter, Extra, ParameterOrExtra, _make_prior_chain
+using LinearAlgebra: I
+using MCMCChains: MCMCChains
 using Random: Xoshiro
 using Test
+
+"""
+Build an `MCMCChains.Chains` from a DynamicPPL model, mimicking what Turing's
+`bundle_samples` does but without depending on Turing.
+
+cf. https://github.com/TuringLang/DynamicPPL.jl/blob/d7e84ce28c004f17e05711ccfd90e6225b2169b8/ext/DynamicPPLMCMCChainsExt.jl#L173-L185
+"""
+function _make_mcmcchains(rng, model, n_iters, n_chains; discard_initial=0, thinning=1)
+    samples = _make_prior_chain(rng, model, n_iters, n_chains; make_chain=false)
+    bare_chain = AbstractMCMC.from_samples(MCMCChains.Chains, samples)
+    start_time = rand(rng, n_chains)
+    stop_time = start_time .+ rand(rng, n_chains)
+    info = merge(
+        bare_chain.info,
+        (
+            start_time=start_time,
+            stop_time=stop_time,
+            samplerstate=_make_sampler_state(n_chains),
+        ),
+    )
+    return MCMCChains.Chains(
+        bare_chain.value.data,
+        names(bare_chain),
+        bare_chain.name_map;
+        info=info,
+        start=discard_initial + 1,
+        thin=thinning,
+    )
+end
+
+_make_sampler_state(n_chains) = [(; x="state_$i") for i in 1:n_chains]
 
 @testset "FlexiChainsMCMCChainsExt" begin
     @testset "FlexiChain{VarName} -> MCMCChains" begin
@@ -13,58 +49,28 @@ using Test
             y ~ MvNormal(zeros(3), I)
             return z ~ LKJCholesky(3, 2.0)
         end
-        mcmcc = sample(
-            Xoshiro(468),
-            f(),
-            NUTS(),
-            20;
-            chain_type=MCMCChains.Chains,
-            verbose=false,
-        )
-        flexic = sample(Xoshiro(468), f(), NUTS(), 20; chain_type=VNChain, verbose=false)
+        flexic = _make_prior_chain(Xoshiro(468), f(), 20, 1)
         new_mcmcc = MCMCChains.Chains(flexic)
-
-        @testset "the data itself" begin
-            @test Set(keys(new_mcmcc)) == Set(keys(mcmcc))
-            for k in keys(new_mcmcc)
-                @test new_mcmcc[k] == mcmcc[k]
-            end
-        end
 
         @testset "iteration indices" begin
             @test FlexiChains.iter_indices(flexic) == range(new_mcmcc)
-            @test range(new_mcmcc) == range(mcmcc)
-        end
-
-        @testset "grouping of data into sections" begin
-            @test Set(keys(new_mcmcc.name_map)) == Set(keys(mcmcc.name_map))
-            for k in keys(new_mcmcc.name_map)
-                # each of these is a vector which may be in a different order
-                @test Set(new_mcmcc.name_map[k]) == Set(mcmcc.name_map[k])
-            end
         end
 
         @testset "sampling time is preserved" begin
-            @test hasproperty(new_mcmcc.info, :start_time)
-            @test hasproperty(new_mcmcc.info, :stop_time)
-            durations = new_mcmcc.info.stop_time .- new_mcmcc.info.start_time
-            @test durations ≈ FlexiChains.sampling_time(flexic)
+            flexic_with_time = VNChain(20, 1, flexic._data; sampling_time=[3.14])
+            mc = MCMCChains.Chains(flexic_with_time)
+            @test hasproperty(mc.info, :start_time)
+            @test hasproperty(mc.info, :stop_time)
+            durations = mc.info.stop_time .- mc.info.start_time
+            @test durations ≈ FlexiChains.sampling_time(flexic_with_time)
         end
 
-        @testset "sampler state is preserved with save_state=true" begin
-            flexic_with_state = sample(
-                Xoshiro(468),
-                f(),
-                NUTS(),
-                20;
-                chain_type=VNChain,
-                verbose=false,
-                save_state=true,
-            )
-            mc_with_state = MCMCChains.Chains(flexic_with_state)
-            @test hasproperty(mc_with_state.info, :samplerstate)
-            @test mc_with_state.info.samplerstate ==
-                  FlexiChains.last_sampler_state(flexic_with_state)
+        @testset "sampler state is preserved" begin
+            flexic_with_state =
+                VNChain(20, 1, flexic._data; last_sampler_state=["some_state"])
+            mc = MCMCChains.Chains(flexic_with_state)
+            @test hasproperty(mc.info, :samplerstate)
+            @test mc.info.samplerstate == FlexiChains.last_sampler_state(flexic_with_state)
         end
     end
 
@@ -91,25 +97,24 @@ using Test
         @test mc[:lp] == chn[:lp]
     end
 
-    @testset "MCMCChains -> FlexiChain{Symbol}" begin
+    @testset "MCMCChains -> FlexiChain (from_mcmcchains)" begin
         @model function g()
             m ~ Normal(0, 1.0)
             s ~ InverseGamma(2, 3)
             return 1.5 ~ Normal(m, sqrt(s))
         end
 
-        @testset "single chain" begin
-            chn = sample(g(), MH(), 100; verbose=false)
-            fc = FlexiChain{Symbol}(chn)
+        @testset "single chain (no key_spec)" begin
+            chn = _make_mcmcchains(Xoshiro(123), g(), 100, 1)
+            fc = FlexiChains.from_mcmcchains(chn)
 
             @test fc isa FlexiChain{Symbol}
             @test size(fc) == (size(chn, 1), size(chn, 3))
 
-            # Key names & grouping
-            @test Set(FlexiChains.parameters(fc)) == Set(names(chn, :parameters))
-            for name in names(chn, :internals)
-                @test Extra(name) in FlexiChains.extras(fc)
-            end
+            # Key names & grouping (order matters)
+            @test collect(FlexiChains.parameters(fc)) == collect(names(chn, :parameters))
+            @test collect(FlexiChains.extras(fc)) ==
+                  [Extra(n) for n in names(chn, :internals)]
             # Data
             for name in names(chn)
                 k = name in names(chn, :parameters) ? Parameter(name) : Extra(name)
@@ -118,31 +123,49 @@ using Test
             # Iteration indices
             @test collect(FlexiChains.iter_indices(fc)) == collect(range(chn))
             # Sampling time
-            @test !any(ismissing, FlexiChains.sampling_time(fc))
-            @test only(FlexiChains.sampling_time(fc)) > 0
+            expected_time = chn.info.stop_time .- chn.info.start_time
+            @test collect(FlexiChains.sampling_time(fc)) ≈ expected_time
+            # Sampler state
+            @test collect(FlexiChains.last_sampler_state(fc)) == _make_sampler_state(1)
         end
 
-        @testset "multiple chains" begin
+        @testset "multiple chains (no key_spec)" begin
             ni, nc = 100, 3
-            chn = sample(g(), MH(), MCMCSerial(), ni, nc; verbose=false)
-            fc = FlexiChain{Symbol}(chn)
+            chn = _make_mcmcchains(Xoshiro(456), g(), ni, nc)
+            fc = FlexiChains.from_mcmcchains(chn)
             @test size(fc) == (ni, nc)
             for name in names(chn, :parameters)
                 @test fc[Parameter(name)] == chn[:, name, :].data
             end
-            st = FlexiChains.sampling_time(fc)
-            @test length(st) == nc
-            # Sometimes the sampling time is exactly 0 -- unsure why, so test for >= rather
-            # than >.
-            @test all(t -> t >= 0, st)
+            expected_time = chn.info.stop_time .- chn.info.start_time
+            @test collect(FlexiChains.sampling_time(fc)) ≈ expected_time
+            # Sampler state
+            @test collect(FlexiChains.last_sampler_state(fc)) == _make_sampler_state(nc)
         end
 
-        @testset "sampler state is preserved" begin
-            chn = sample(g(), MH(), 50; verbose=false, save_state=true)
-            @test hasproperty(chn.info, :samplerstate)
-            fc = FlexiChain{Symbol}(chn)
-            lss = FlexiChains.last_sampler_state(fc)
-            @test !all(ismissing, lss)
+        @testset "iteration indices with discard and thinning" begin
+            chn =
+                _make_mcmcchains(Xoshiro(111), g(), 50, 1; discard_initial=100, thinning=3)
+            fc = FlexiChains.from_mcmcchains(chn)
+            ii = collect(FlexiChains.iter_indices(fc))
+            @test collect(ii) == collect(range(chn)) == 101:3:250
+        end
+
+        @testset "with custom key_spec" begin
+            chn = _make_mcmcchains(Xoshiro(321), g(), 100, 1)
+            nparams = length(names(chn))
+            ks = tuple((Parameter(Symbol("p$i")) for i in 1:nparams)...)
+            fc = FlexiChains.from_mcmcchains(chn, ks)
+            @test fc isa FlexiChain{Symbol}
+            @test size(fc) == (size(chn, 1), size(chn, 3))
+            @test collect(FlexiChains.parameters(fc)) == [Symbol("p$i") for i in 1:nparams]
+        end
+
+        @testset "deprecated constructor still works" begin
+            chn = _make_mcmcchains(Xoshiro(654), g(), 50, 1)
+            fc = @test_deprecated FlexiChain{Symbol}(chn)
+            @test fc isa FlexiChain{Symbol}
+            @test size(fc) == (size(chn, 1), size(chn, 3))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,7 @@ else
         include("flatten.jl")
         include("ext/advancedhmc.jl")
 
-        # TODO: reenable!
-        # include("ext/mcmcchains.jl")
+        include("ext/mcmcchains.jl")
         # include("ext/dimdist.jl")
 
         include("ext/dynamicppl.jl")


### PR DESCRIPTION
This PR:

- Deprecates `FlexiChain{Symbol}(::MCMCChains.Chains)`
- Adds a new `FlexiChains.from_mcmcchains(::MCMCChains.Chains)` function, which is a strict superset of the above in terms of functionality. It also uses the new 3D array constructor for a FlexiChain, which saves on some code duplication.
- Reworks the MCMCChainsExt tests so that they no longer depend on sampling with Turing. They were previously disabled due to this, so this PR also reenables them.

Closes #212
Closes #213