### PR TITLE
Pin DPPL to 0.41 in Pigeons tests (for now)

### DIFF
--- a/test/pigeons/Project.toml
+++ b/test/pigeons/Project.toml
@@ -7,6 +7,9 @@ Pigeons = "0eb8d820-af6a-4919-95ae-11206f830c31"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[compat]
+DynamicPPL = "0.41"
+
 [sources]
 FlexiChains = {path = "../.."}
 Pigeons = {rev = "main", url = "https://github.com/penelopeysm/Pigeons.jl"}


### PR DESCRIPTION
DPPL's AD changes actually broke the Pigeons PR, see https://github.com/Julia-Tempering/Pigeons.jl/pull/442#discussion_r3566256807, so I have to pin this for now. Play stupid games win stupid prizes ig