### PR TITLE
Use `typejoin` to figure out parameter types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# 0.6.29
+
+Fixed a bug where `FlexiChains.from_mcmcchains` would error if given Parameters with different `VarName`s (which made it very hard to convert an `MCMCChains.Chains` object to a `VNChain`, instead of the standard `SymChain`).
+
+Improved the behaviour of `map_keys` and `map_parameters` to give better key types in the output FlexiChain.
+
 # 0.6.28
 
 Added a function `FlexiChains.from_mcmcchains` to convert from an `MCMCChains.Chains` object.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.28"
+version = "0.6.29"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/mcmcchains.md
+++ b/docs/src/mcmcchains.md
@@ -37,11 +37,17 @@ using FlexiChains: Parameter, Extra
 
 fc = FlexiChains.from_mcmcchains(
     mc,
-    (Parameter(:x), Parameter(:y), Parameter(:z) => (2,), Extra(:logp)),
+    (
+        Parameter(@varname(x)),
+        Parameter(@varname(y)),
+        Parameter(@varname(z)) => (2,),
+        Extra(:logp),
+    ),
 )
 ```
 
-By specifying the shape of `z` as `(2,)`, we can recover the vector structure of that parameter.
+By passing `VarName` parameters instead of `Symbol`s, we can 'upconvert' this into a `VNChain` rather than a `SymChain` (which is harder to index into, for example, if you want to get `z[1]`).
+Furthermore, by specifying the shape of `z` as `(2,)`, we can recover the vector structure of that parameter.
 In general array-valued parameters can be 'recovered' in this way, but more complicated structs cannot be.
 
 !!! warning "Order of parameters"
@@ -52,7 +58,7 @@ In general array-valued parameters can be 'recovered' in this way, but more comp
 After that, you might also want to convert `y` back into a Boolean:
 
 ```@example mcmcchains
-fc = FlexiChains.transform_values(fc, :y => Bool)
+fc = FlexiChains.transform_values(fc, @varname(y) => Bool)
 ```
 
 ## FlexiChain to MCMCChains

--- a/ext/FlexiChainsMCMCChainsExt.jl
+++ b/ext/FlexiChainsMCMCChainsExt.jl
@@ -109,13 +109,14 @@ function FlexiChains.from_mcmcchains(
 end
 
 function _infer_key_type(key_spec::Tuple)
+    T = Union{}
     for k in key_spec
         key = k isa Pair ? first(k) : k
         if key isa Parameter
-            return typeof(key).parameters[1]
+            T = typejoin(T, typeof(key).parameters[1])
         end
     end
-    return Symbol
+    return T
 end
 
 # I can't seem to get Base.@deprecate to work

--- a/src/interface/dict.jl
+++ b/src/interface/dict.jl
@@ -113,10 +113,9 @@ end
 Figure out the new key type for a FlexiChain or FlexiSummary after mapping keys with `f`.
 """
 function _get_new_keytype(f, ks::Base.KeySet)
-    # This is surprisingly hard!
-    all_keys = collect(ks)
     seen = Set()
-    for k in all_keys
+    TKey = Union{}
+    for k in ks
         new_key = f(k)
         if !(new_key isa ParameterOrExtra)
         end
@@ -129,14 +128,11 @@ function _get_new_keytype(f, ks::Base.KeySet)
         else
             push!(seen, new_key)
         end
+        if new_key isa Parameter
+            TKey = typejoin(TKey, typeof(new_key).parameters[1])
+        end
     end
-    new_params = filter(k -> k isa Parameter, collect(seen))
-    new_param_names = map(p -> p.name, new_params)
-    return if isempty(new_param_names)
-        Any
-    else
-        eltype(new_param_names)
-    end
+    return TKey
 end
 
 """
@@ -165,6 +161,7 @@ Change the parameters of a `FlexiChain` or `FlexiSummary` by applying the functi
 """
 function map_parameters(f, cs::ChainOrSummary)
     seen = Set()
+    TKey = Union{}
     for p in parameters(cs)
         newp = f(p)
         if newp in seen
@@ -176,12 +173,12 @@ function map_parameters(f, cs::ChainOrSummary)
         else
             push!(seen, newp)
         end
+        TKey = typejoin(TKey, typeof(newp))
     end
-    new_keytype = eltype(map(identity, collect(seen)))
     wrapper_f = k -> k isa Parameter ? Parameter(f(k.name)) : k
     N = cs isa FlexiChain ? 2 : 3
-    new_data = OrderedDict{ParameterOrExtra{<:new_keytype},Array{<:Any,N}}(
+    new_data = OrderedDict{ParameterOrExtra{<:TKey},Array{<:Any,N}}(
         wrapper_f(k) => v for (k, v) in pairs(cs._data)
     )
-    return _replace_data(cs, new_keytype, new_data)
+    return _replace_data(cs, TKey, new_data)
 end

--- a/test/ext/mcmcchains.jl
+++ b/test/ext/mcmcchains.jl
@@ -161,6 +161,24 @@ _make_sampler_state(n_chains) = [(; x="state_$i") for i in 1:n_chains]
             @test collect(FlexiChains.parameters(fc)) == [Symbol("p$i") for i in 1:nparams]
         end
 
+        @testset "with upconversion to VarName" begin
+            chn = _make_mcmcchains(Xoshiro(321), g(), 100, 1)
+            nparams = length(names(chn))
+            ks = (
+                Parameter(@varname(x)),
+                Parameter(@varname(y)) => (nparams - 2,),
+                Parameter(@varname(z[1])),
+            )
+            fc = FlexiChains.from_mcmcchains(chn, ks)
+            @test fc isa FlexiChain{VarName}
+            @test size(fc) == (size(chn, 1), size(chn, 3))
+            @test collect(FlexiChains.parameters(fc)) ==
+                  [@varname(x), @varname(y), @varname(z[1])]
+            @test eltype(fc[@varname(x)]) == Float64
+            @test eltype(fc[@varname(y)]) == Vector{Float64}
+            @test eltype(fc[@varname(z[1])]) == Float64
+        end
+
         @testset "deprecated constructor still works" begin
             chn = _make_mcmcchains(Xoshiro(654), g(), 50, 1)
             fc = @test_deprecated FlexiChain{Symbol}(chn)


### PR DESCRIPTION
Closes #290. This allows you to use a keyspec of `(Parameter(@varname(x)), Parameter(@varname(y)))`. The resulting key type will be

```julia
julia> typejoin(typeof(@varname(x)), typeof(@varname(y)))
VarName{sym, AbstractPPL.Iden} where sym
```

which is not quite the same as `VarName`, but it's good enough.

And I'd argue this also closes #291 because it removes the scenario where you have to specify `(Parameter{VarName}(@varname(x)), Parameter{VarName}(@varname(y)))`.