### PR TITLE
Use upstream Vitepress

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -34,7 +34,7 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [sources]
 Pigeons = {rev = "main", url = "https://github.com/penelopeysm/Pigeons.jl"}
-DocumenterVitepress = {rev = "main", url = "https://github.com/penelopeysm/DocumenterVitepress.jl"}
+DocumenterVitepress = {rev = "main", url = "https://github.com/LuxDL/DocumenterVitepress.jl"}
 
 [compat]
 AbstractMCMC = "5.14"

--- a/docs/src/.vitepress/theme/overrides.css
+++ b/docs/src/.vitepress/theme/overrides.css
@@ -1,8 +1,0 @@
-:root {
-  --vp-code-color: var(--vp-c-text-1);
-}
-
-.custom-block.tip code {
-  color: var(--vp-c-text-1);
-  background-color: var(--vp-code-bg);
-}


### PR DESCRIPTION
Now that the fixes I wanted are in, we can just use upstream! I don't think a release has been cut yet, but we can easily point to the main branch.

https://github.com/LuxDL/DocumenterVitepress.jl/pull/380