### PR TITLE
Don't ignore axis kwargs on pushforward_discrete

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.6.32
+
+Fixed a bug where `pushforward_discrete` would override user-specified axis attributes for `xticks`, or `yticks` (depending on whether `vertical == true`), `xlabel`, and `ylabel`.
+
 # 0.6.31
 
 Improved the resulting key type when attempting to construct `VNChain`s from `FlexiChains.from_mcmcchains`, `FlexiChains.map_keys`, or `FlexiChains.map_parameters`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.31"
+version = "0.6.32"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 
 [deps]

--- a/ext/FlexiChainsMakieExt/pushforward_discrete.jl
+++ b/ext/FlexiChainsMakieExt/pushforward_discrete.jl
@@ -1,3 +1,11 @@
+function _default_pushforward_discrete_axis(vertical)
+    if vertical
+        (; xlabel="parameter", ylabel="value")
+    else
+        (; xlabel="value", ylabel="parameter")
+    end
+end
+
 function _pushforward_discrete_bands(data, quantiles, baseline, residual)
     isodd(length(quantiles)) || throw(ArgumentError("`quantiles` must have odd length"))
     n = length(data)
@@ -97,11 +105,12 @@ function FC.Makie.pushforward_discrete(
     param;
     figure=(;),
     axis=(;),
+    vertical::Bool=true,
     kwargs...,
 )
     fig = isempty(figure) ? Figure() : Figure(; figure...)
-    ax = Makie.Axis(fig[1, 1]; axis...)
-    _, p = FC.Makie.pushforward_discrete!(ax, chn, param; kwargs...)
+    ax = Makie.Axis(fig[1, 1]; _default_pushforward_discrete_axis(vertical), axis...)
+    _, p = FC.Makie.pushforward_discrete!(ax, chn, param; vertical, kwargs...)
     return Makie.FigureAxisPlot(fig, ax, p)
 end
 
@@ -124,12 +133,8 @@ function FC.Makie.pushforward_discrete!(
     ticks = (1:length(ks), kstrs)
     if vertical
         ax.xticks = ax.xticks[] === Makie.automatic ? ticks : ax.xticks[]
-        ax.xlabel = isempty(ax.xlabel[]) ? "parameter" : ax.xlabel[]
-        ax.ylabel = isempty(ax.ylabel[]) ? "value" : ax.ylabel[]
     else
-        ax.yticks = ax.xticks[] === Makie.automatic ? ticks : ax.yticks[]
-        ax.xlabel = isempty(ax.xlabel[]) ? "value" : ax.xlabel[]
-        ax.ylabel = isempty(ax.ylabel[]) ? "parameter" : ax.ylabel[]
+        ax.yticks = ax.yticks[] === Makie.automatic ? ticks : ax.yticks[]
     end
     return _plot_pushforward_discrete!(ax, data; vertical, kwargs...)
 end

--- a/ext/FlexiChainsMakieExt/pushforward_discrete.jl
+++ b/ext/FlexiChainsMakieExt/pushforward_discrete.jl
@@ -123,13 +123,13 @@ function FC.Makie.pushforward_discrete!(
     end
     ticks = (1:length(ks), kstrs)
     if vertical
-        ax.xticks = ticks
-        ax.xlabel = "parameter"
-        ax.ylabel = "value"
+        ax.xticks = isempty(ax.xticks[]) ? ticks : ax.xticks[]
+        ax.xlabel = isempty(ax.xlabel[]) ? "parameter" : ax.xlabel[]
+        ax.ylabel = isempty(ax.ylabel[]) ? "value" : ax.ylabel[]
     else
-        ax.yticks = ticks
-        ax.xlabel = "value"
-        ax.ylabel = "parameter"
+        ax.yticks = isempty(ax.yticks[]) ? ticks : ax.yticks[]
+        ax.xlabel = isempty(ax.xlabel[]) ? "value" : ax.xlabel[]
+        ax.ylabel = isempty(ax.ylabel[]) ? "parameter" : ax.ylabel[]
     end
     return _plot_pushforward_discrete!(ax, data; vertical, kwargs...)
 end

--- a/ext/FlexiChainsMakieExt/pushforward_discrete.jl
+++ b/ext/FlexiChainsMakieExt/pushforward_discrete.jl
@@ -109,7 +109,7 @@ function FC.Makie.pushforward_discrete(
     kwargs...,
 )
     fig = isempty(figure) ? Figure() : Figure(; figure...)
-    ax = Makie.Axis(fig[1, 1]; _default_pushforward_discrete_axis(vertical), axis...)
+    ax = Makie.Axis(fig[1, 1]; _default_pushforward_discrete_axis(vertical)..., axis...)
     _, p = FC.Makie.pushforward_discrete!(ax, chn, param; vertical, kwargs...)
     return Makie.FigureAxisPlot(fig, ax, p)
 end

--- a/ext/FlexiChainsMakieExt/pushforward_discrete.jl
+++ b/ext/FlexiChainsMakieExt/pushforward_discrete.jl
@@ -123,11 +123,11 @@ function FC.Makie.pushforward_discrete!(
     end
     ticks = (1:length(ks), kstrs)
     if vertical
-        ax.xticks = isempty(ax.xticks[]) ? ticks : ax.xticks[]
+        ax.xticks = ax.xticks[] === Makie.automatic ? ticks : ax.xticks[]
         ax.xlabel = isempty(ax.xlabel[]) ? "parameter" : ax.xlabel[]
         ax.ylabel = isempty(ax.ylabel[]) ? "value" : ax.ylabel[]
     else
-        ax.yticks = isempty(ax.yticks[]) ? ticks : ax.yticks[]
+        ax.yticks = ax.xticks[] === Makie.automatic ? ticks : ax.yticks[]
         ax.xlabel = isempty(ax.xlabel[]) ? "value" : ax.xlabel[]
         ax.ylabel = isempty(ax.ylabel[]) ? "parameter" : ax.ylabel[]
     end


### PR DESCRIPTION
`pushforward_discrete` currently ignores user-specified axis kwargs and overrides the axis ticks and labels with parameter names (almost always desirable!), "parameter" and "value", respectively.

I think these are good defaults, but we shouldn't override what the user passed. Could be that Claude did this and we didn't catch it yet.

I didn't add a test for this, but tested the behavior with the function below:

```julia
function test(; axis=(;))
	fig = Figure()
	ax = Axis(fig[1, 1]; axis...)
	ax.xlabel = isempty(ax.xlabel[]) ? "was empty" : ax.xlabel[]
	return fig
end
```

Maybe there's a more elegant way to achieve this, too.