### PR TITLE
[skip ci] fix TagBot perms

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
   workflow_dispatch:
+  
+permissions:
+  contents: write
 
 jobs:
   TagBot:


### PR DESCRIPTION
Since when was this needed? Just another GHA thing i guess...