### PR TITLE
Improve show on FlexiSummary

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# 0.6.35
+
+`FlexiSummary` now pretty-prints a table as long as there is at most one non-collapsed dimension.
+
+In particular, this means that things like `mean(chn; dims=:iter)` and `mean(chn; dims=:chain)` will now pretty-print a table of means, instead of forcing the user to index into it to see the results.
+
 # 0.6.34
 
 Added a shorthand for `getindex` on `FlexiSummary`: `s[key, stat=:mystat]` is now equivalent to `s[key, stat=At(:mystat)]`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.34"
+version = "0.6.35"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 
 [deps]

--- a/src/interface/show.jl
+++ b/src/interface/show.jl
@@ -358,16 +358,18 @@ function _print_summary_table(
     MAX_COL_WIDTH = 12
     inner_width = width - 4
     colpadding = 2
-    # No column can occupy fewer than one character plus its padding. Avoid formatting
-    # columns which could not possibly be displayed, regardless of their contents.
+
+    # For things like `mean(chain, dims=:chain)`, there could be a huge number of columns,
+    # very few of which will actually be displayed. To avoid performing unnecessary
+    # formatting work we cap the number of columns to be formatted.
     max_formatted_columns = max(div(inner_width, colpadding + 1), 1)
+    columns_were_skipped =
+        !isnothing(column_indices) && length(column_indices) > max_formatted_columns
 
     header_col =
         ["param", map(p -> _truncate(_pretty_value(p), MAX_COL_WIDTH), param_names)...]
     param_values = map(pn -> summary[pn], param_names)
 
-    columns_were_skipped =
-        !isnothing(column_indices) && length(column_indices) > max_formatted_columns
     value_cols = if isnothing(column_indices)
         [["", [_truncate(_pretty_value(value), MAX_COL_WIDTH) for value in param_values]...],]
     else

--- a/src/interface/show.jl
+++ b/src/interface/show.jl
@@ -346,7 +346,8 @@ function _print_summary_table(
     io::IO,
     summary::FlexiSummary,
     param_names::Vector,
-    si,
+    column_indices,
+    first_column_prefix::String,
     width::Int,
 )
     _box_empty(io, width)
@@ -357,33 +358,44 @@ function _print_summary_table(
     MAX_COL_WIDTH = 12
     inner_width = width - 4
     colpadding = 2
+    # No column can occupy fewer than one character plus its padding. Avoid formatting
+    # columns which could not possibly be displayed, regardless of their contents.
+    max_formatted_columns = max(div(inner_width, colpadding + 1), 1)
 
     header_col =
         ["param", map(p -> _truncate(_pretty_value(p), MAX_COL_WIDTH), param_names)...]
+    param_values = map(pn -> summary[pn], param_names)
 
-    stat_cols = if isnothing(si)
-        [["", [_truncate(_pretty_value(summary[pn]), MAX_COL_WIDTH) for pn in param_names]...],]
+    columns_were_skipped =
+        !isnothing(column_indices) && length(column_indices) > max_formatted_columns
+    value_cols = if isnothing(column_indices)
+        [["", [_truncate(_pretty_value(value), MAX_COL_WIDTH) for value in param_values]...],]
     else
-        map(enumerate(parent(si))) do (stat_i, stat_name)
+        column_names = Iterators.take(parent(column_indices), max_formatted_columns)
+        map(enumerate(column_names)) do (column_i, column_name)
+            column_header = _pretty_value(column_name)
+            if column_i == 1
+                column_header = first_column_prefix * column_header
+            end
             [
-                String(stat_name)
+                _truncate(column_header, MAX_COL_WIDTH)
                 [
-                    _truncate(_pretty_value(summary[pn][stat_i]), MAX_COL_WIDTH) for
-                    pn in param_names
+                    _truncate(_pretty_value(value[column_i]), MAX_COL_WIDTH) for
+                    value in param_values
                 ]...
             ]
         end
     end
 
-    rows = hcat(header_col, stat_cols...)
+    rows = hcat(header_col, value_cols...)
     colwidths = map(maximum, eachcol(map(length, rows)))
 
     total = sum(cw + colpadding for cw in colwidths)
-    if total <= inner_width
+    truncated = columns_were_skipped || total > inner_width
+    available = inner_width - (truncated ? 3 : 0)
+    if total <= available
         max_cols = length(colwidths)
-        truncated = false
     else
-        available = inner_width - 3
         cumwidth = colwidths[1] + colpadding
         max_cols = 1
         for j in 2:length(colwidths)
@@ -395,7 +407,6 @@ function _print_summary_table(
                 break
             end
         end
-        truncated = true
     end
 
     for (i, row) in enumerate(eachrow(rows))
@@ -469,8 +480,24 @@ function Base.show(io::IO, ::MIME"text/plain", summary::FlexiSummary{TKey}) wher
         _eltype_groups(summary, false),
     )
 
-    if isnothing(ii) && isnothing(ci) && !isempty(param_names)
-        _print_summary_table(io, summary, param_names, si, width)
+    uncollapsed_indices = filter(!isnothing, (ii, ci, si))
+    if length(uncollapsed_indices) <= 1 && !isempty(param_names)
+        column_indices = isempty(uncollapsed_indices) ? nothing : only(uncollapsed_indices)
+        first_column_prefix = if !isnothing(column_indices) && column_indices === ii
+            "iter "
+        elseif !isnothing(column_indices) && column_indices === ci
+            "chain "
+        else
+            ""
+        end
+        _print_summary_table(
+            io,
+            summary,
+            param_names,
+            column_indices,
+            first_column_prefix,
+            width,
+        )
     end
 
     _box_bottom(io, width)


### PR DESCRIPTION
Closes #301. Mostly gpt 5.6-sol although I had to steer it quite a bit

With this PR, these all get pretty-printed more informatively. Previously neither of these would print the table.

```julia
julia> mean(chain; dims=:chain)
╭─FlexiSummary (1000 iterations) ─────────────────────────────────────────────────╮
│ ↓ iter  = 1:1000                                                                │
│   chain   collapsed                                                             │
│   stat    collapsed                                                             │
│                                                                                 │
│ Parameters (4) ── VarName                                                       │
│  Float64  x, y, z[1], z[2]                                                      │
│                                                                                 │
│ Extras (3)                                                                      │
│  Float64  logprior, loglikelihood, logjoint                                     │
│                                                                                 │
│ Summary                                                                         │
│   param   iter 1        2        3        4        5        6        7  …       │
│       x  -0.4665   0.0040  -0.8951  -0.5671   0.2668  -0.2212  -0.1465  …       │
│       y   3.7500   3.0000   4.7500   2.7500   2.5000   2.2500   3.0000  …       │
│    z[1]   2.4330   2.9822   4.0234   2.3597   2.6514   2.1818   2.6713  …       │
│    z[2]  -4.3298  -3.7517  -5.8727  -2.8362  -2.4498  -2.3577  -2.7739  …       │
╰─────────────────────────────────────────────────────────────────────────────────╯

julia> mean(chain; dims=:iter)
╭─FlexiSummary (4 chains) ────────────────────────────────────────────────────────╮
│   iter    collapsed                                                             │
│ ↓ chain = 1:4                                                                   │
│   stat    collapsed                                                             │
│                                                                                 │
│ Parameters (4) ── VarName                                                       │
│  Float64  x, y, z[1], z[2]                                                      │
│                                                                                 │
│ Extras (3)                                                                      │
│  Float64  logprior, loglikelihood, logjoint                                     │
│                                                                                 │
│ Summary                                                                         │
│   param  chain 1        2        3        4                                     │
│       x  -0.0515  -0.0012   0.0304   0.0566                                     │
│       y   2.9610   2.9800   2.9160   2.9800                                     │
│    z[1]   2.9460   3.0052   2.9173   2.9914                                     │
│    z[2]  -3.0420  -2.9446  -2.8810  -2.9421                                     │
╰─────────────────────────────────────────────────────────────────────────────────╯
```