### PR TITLE
Fix PairPlotsExt with nonstandard indexing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.6.37
+
+Fixed a bug where `pairplot(chn)` would fail if `chn` had chains that were not 1-indexed.
+
 # 0.6.36
 
 Added an extension for MonteCarloMeasurements.jl which allows you to convert a `FlexiChain` into a `Particles`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.36"
+version = "0.6.37"
 authors = ["Penelope Yong <penelopeysm@gmail.com> and contributors"]
 
 [deps]

--- a/ext/FlexiChainsPairPlotsExt.jl
+++ b/ext/FlexiChainsPairPlotsExt.jl
@@ -101,7 +101,7 @@ function PairPlots.pairplot(
     else
         Tuple(
             PairPlots.Series(
-                chn[chain=ci];
+                chn[chain=FC.At(ci)];
                 split_varnames=false,
                 _plot_names=plot_names,
                 label="chain $ci",


### PR DESCRIPTION
Closes #328, tested locally but don't want to add it to CI as I don't want to generate more test images